### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [16/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -22,6 +22,9 @@
   "deployment": {
     "keystone": {
       "crowbar-revision": 0,
+      "element_states": {
+        "keystone-server": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
          ["keystone-server" ]       		           		     

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -30,6 +30,12 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": { "type": "map", "mapping": {
+                = : { "type": "seq", "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": { "type": "map", "required": true,
               "mapping": {
                 = : {"type": "seq", "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-keystone.json   |    3 +++
 chef/data_bags/crowbar/bc-template-keystone.schema |    6 ++++++
 2 files changed, 9 insertions(+), 0 deletions(-)
