### PR TITLE
Fix endpoint issue

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -218,7 +218,7 @@ action :add_endpoint_template do
       matched_service = false
       data = JSON.parse(data)
       data["endpoints"].each do |endpoint|
-          if endpoint["service_id"].to_i === my_service_id.to_i
+          if endpoint["service_id"].to_s === my_service_id.to_s
               matched_service = true
               break
           end


### PR DESCRIPTION
String with hexadecimal values becomes 0 after this conversion.

Keystone from essex-4 milestone is using UUID hex values instead of integer for endpoints, so converting to string should be safer.
