### PR TITLE
Fix readding keystone service on every chef-client run

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -222,5 +222,5 @@ end
 
 node[:keystone][:monitor] = {} if node[:keystone][:monitor].nil?
 node[:keystone][:monitor][:svcs] = [] if node[:keystone][:monitor][:svcs].nil?
-node[:keystone][:monitor][:svcs] <<["keystone"]
+node[:keystone][:monitor][:svcs] << ["keystone"] if node[:keystone][:monitor][:svcs].empty?
 node.save


### PR DESCRIPTION
hi, i hope that somebody forgot to perform check before adding new array member "keystone". Thanks!
