### PR TITLE
Fix missed ordering [1/4]

### DIFF
--- a/crowbar_framework/db/migrate/20120802030000_barclamp_import_keystone.rb
+++ b/crowbar_framework/db/migrate/20120802030000_barclamp_import_keystone.rb
@@ -1,0 +1,24 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class BarclampImportKeystone < ActiveRecord::Migration
+  def up
+    Barclamp.import_1x 'keystone'
+  end
+
+  def down
+    Barclamp.delete(Barclamp.find_by_name 'keystone')
+  end
+  
+end


### PR DESCRIPTION
Missing keystone in migration renumbering/
Also, OpenStack does not require these barclamp

 .../20120801015035_barclamp_import_keystone.rb     |   24 --------------------
 .../20120802030000_barclamp_import_keystone.rb     |   24 ++++++++++++++++++++
 2 files changed, 24 insertions(+), 24 deletions(-)
