### PR TITLE
Make locking more debuggable, and start reworking smoketests. [5/6]

### DIFF
--- a/smoketest/00-check-keystone.test
+++ b/smoketest/00-check-keystone.test
@@ -7,6 +7,7 @@ keystone_nodes="$(knife_node_find 'roles:keystone-server' FQDN)"
 }
 unset http_proxy
 
+apt-get install python-keystoneclient
 for node in $keystone_nodes; do
     token=$(curl -sS -d \
         $'{"auth":{"passwordCredentials":{"username":"admin","password":"crowbar"}}}' \
@@ -18,4 +19,7 @@ for node in $keystone_nodes; do
     }
     echo "$token" > "$LOGDIR/keystone-token.json"
     echo "Keystone up on $node"
+    [[ -f $HOME/.openrc ]] || scp "$node:/root/.openrc" "$HOME/.openrc"
 done
+
+


### PR DESCRIPTION
- Replace acquire_lock and release_lock with a single try_lock function.
- Convert all users of acquire_lock and release_lock to use try_lock.
- Add instrumentation to try_lock to blow up informativey on deadlock.
- Chop out parts of openstack smoketests that are not applicable.
  
  smoketest/00-check-keystone.test |    4 ++++
  1 file changed, 4 insertions(+)

Crowbar-Pull-ID: 0007483fe1414a718d9d6de4c89b95020d7b4f05

Crowbar-Release: development
