### PR TITLE
Unit test additions and clean-up to enable the mysql barclamp to be applied [3/3]

### DIFF
--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -30,10 +30,10 @@ class KeystoneService < ServiceObject
     nodes = Node.all
     nodes.delete_if { |n| n.nil? or n.is_admin? }
     if nodes.size >= 1
-      add_role_to_instance_and_node(n[0].name, base.name, "keystone-server")
+      add_role_to_instance_and_node(nodes[0].name, base.name, "keystone-server")
     end
 
-    hash = base.config_hash
+    hash = base.current_config.config_hash
     hash["keystone"]["mysql_instance"] = ""
     begin
       mysql = Barclamp.find_by_name("mysql")
@@ -52,9 +52,9 @@ class KeystoneService < ServiceObject
       hash["keystone"]["sql_engine"] = "mysql"
     end
 
-    hash["keystone"][:service][:token] = '%012d' % rand(1e12)
+    hash["keystone"]["service"]["token"] = '%012d' % rand(1e12)
 
-    base.config_hash = hash
+    base.current_config.config_hash = hash
 
     base
   end


### PR DESCRIPTION
In this pull request set, the following things are addressed:
1. Addition of a mostly complete unit test for the proposal_config model
2. Clean-up of warnings in the BDD code in both crowbar and network barclamps
3. Fix error/bug in keystone that keeps it from being created.

As a side effect of the unit test for proposal_config, there are lots of 
bugs fixed with the side effect that the mysql barclamp can be create and committed.

Keystone can be applied, but dependency checks fail.  More unit tests needed for that.

 crowbar_framework/app/models/keystone_service.rb |    8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 56db139c1ebcc1e94094f4219193c0e4e205ec04

Crowbar-Release: development
