### PR TITLE
sets of changes and unit tests that seem to get nova running somewhat [5/6]

### DIFF
--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -19,7 +19,7 @@ class KeystoneService < ServiceObject
     answer = []
     hash = prop_config.config_hash
     if hash["keystone"]["sql_engine"] == "mysql"
-      answer << { "barclamp" => "mysql", "inst" => hash["mysql_instance"] }
+      answer << { "barclamp" => "mysql", "inst" => hash["keystone"]["mysql_instance"] }
     end
     answer
   end


### PR DESCRIPTION
In this pull request set, the following things are addressed:
1. Addition of a mostly complete unit test for the proposal_config model
2. Clean-up of warnings in the BDD code in both crowbar and network barclamps
3. Fix error/bug in keystone that keep it from being created.
4. Fix error/bug in glance that keep it from being created.
5. Fix/change update_proposal_status to operate on the proposal_config and not the active proposal.
6. Fix bug in queue proposal if a list contains a duplicate node list 
7. Add unit test to demonstrate and validate fix for 6 above
8. Tweaks to openstack barclamps (except swift) to get them to work in cb2.0
9. Cherry-pick folsom support from Fred PFS in dashboard.

As a side effect of the unit test for proposal_config, there are lots of
bugs fixed with the side effect that the mysql barclamp can be create and committed.

With this pull request, nova seems to run and start an instance can be launched from
the dashboard.

 crowbar_framework/app/models/keystone_service.rb |   10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: e4517a40898eab087212433a7dea764948978fc6

Crowbar-Release: development
