### PR TITLE
Make feature/grizzly a little more amenable to being built in the Dell build and test env. [5/11]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -67,4 +67,4 @@ debs:
     - libapache2-mod-wsgi
 
 git_repo:
-  - keystone http://github.com/openstack/keystone.git grizzly-1
+  - keystone https://github.com/openstack/keystone.git grizzly-1


### PR DESCRIPTION
This pull request series starts at making PFS builds use the build
cache in a wway that is compatible with performing offline builds.
- Reorder the cache staging processes in the main build process to
  stage things cache by cache instead of barclamp by barclamp.  This
  ensures that all custom barclamp build actions can see the complete
  state of the cache for all barclamps, instead of only seeing the
  cache of the barclamps that were staged before them.
- Add support for stashing the complete barclamp metadata from the
  crowbar.yml files into the barclamps data bag in Chef.
- Add support into the build system for making complete clones of git
  repositories and saving them as tar.bz2 files in the build cache.
- Erase the git barclamp's custom build action for staging git
  repositories.  The build system handles this for us now.
- Fix up the git barclamp to conform to how the build system staged
  cached git repository clones.
- Fix up the crowbar.yml files to be ruby 1.9 compatible
- Several misc. bugfixes.

Still to be done is to intergrate PIP cache handling into the main
build system -- curently, we only use this functionality for PFS.

This patch series also slightly modifies how one invokes a PFS build.
Specifically, you need to pass the --update-pfs-caches flag to allow
the build system to clone or update its cached git checkouts.

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 9a77ef6723b715acfb8d892036d330758f85a940

Crowbar-Release: feature/grizzly
