### PR TITLE
Get Pebbles to be able to deploy Nova and spin up vms. [5/6]

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -63,7 +63,6 @@ elsif node[:keystone][:frontend]=='apache'
   service "keystone" do
     supports :status => true, :restart => true
     action [ :disable, :stop ]
-    ignore_failure true
   end
 
   include_recipe "apache2"


### PR DESCRIPTION
These pull request updates allow Nova and all its prerequisites to
deploy using their default proposals, and test that Nova is able to
spin up a VM.

We still need to have proper smoketests for Quantum and Cinder, and
the Nova smoketests need to include testing attaching and detaching
networks and volumes to vms.

 chef/cookbooks/keystone/recipes/server.rb |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: a0c8ce902ba2ff2b08a2b4fcf2938992f2e17f34

Crowbar-Release: pebbles
