### PR TITLE
Turn down default logging verbosity for glance, ipmi, swift, and keystone. [4/4]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -1,12 +1,11 @@
-
 {
   "id": "bc-template-keystone",
   "description": "Centralized authentication and authorization service for OpenStack",
   "attributes": {
     "keystone": {
-      "debug": true,
+      "debug": false,
       "frontend": "apache",
-      "verbose": true,
+      "verbose": false,
       "signing": "PKI",
       "gitrepo": "http://github.com/openstack/keystone.git",
       "git_instance": "",
@@ -77,7 +76,7 @@
       },
       "elements": {},
       "element_order": [
-         ["keystone-server" ]       		           		     
+         ["keystone-server" ]
       ],
       "config": {
         "environment": "keystone-config-base",
@@ -88,4 +87,3 @@
     }
   }
 }
-


### PR DESCRIPTION
We were being too verbose in our logging by default.  This pull
request turns down the volume so we don't drown in logfiles quite so fast.

 chef/data_bags/crowbar/bc-template-keystone.json |    8 +++-----
 1 file changed, 3 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: 898b27a701f199b0536ae0303358a67f6f08c00f

Crowbar-Release: pebbles
