### PR TITLE
Fix Glance smoketest to not be written for Diablo. [2/2]

### DIFF
--- a/smoketest/00-check-keystone.test
+++ b/smoketest/00-check-keystone.test
@@ -17,5 +17,5 @@ for node in $keystone_nodes; do
         exit 1
     }
     echo "$token" > "$LOGDIR/keystone-token.json"
-    echo "Keystone up on $node"
+    echo "Able to authenticate admin:crowbar on Keystone at $node."
 done


### PR DESCRIPTION
The Glance was initially wrotten for Diablo, which did not have
Keystone to act as a central repository, and so was much more
complicated than it had to be.  This pull request simplifies it.

It also makes the Keystone smoketest actually say where Keystone is.

 smoketest/00-check-keystone.test |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 242742b4b067a7627f01458f3367e810cecd83dd

Crowbar-Release: pebbles
