### PR TITLE
Remove UUID option from token selection in Keystone [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -13,7 +13,7 @@
 
     %p
       %label{ :for => :token_format }= t('.token_format')
-      = select_tag :token_format, options_for_select([['PKI','PKI'], ['UUID', 'UUID']], @proposal.raw_data['attributes'][@proposal.barclamp]["token_format"].to_s), :onchange => "update_value('token_format', 'token_format', 'string')"
+      = select_tag :token_format, options_for_select([['PKI','PKI']], @proposal.raw_data['attributes'][@proposal.barclamp]["token_format"].to_s), :onchange => "update_value('token_format', 'token_format', 'string')"
     %p
       %label{ :for => :default_tenant }= t('.default-tenant')
       %input#default_tenant{:type => "text", :name => "default_tenant", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["default"]["tenant"], :onchange => "update_value('default/tenant','default_tenant','string')"}


### PR DESCRIPTION
Remove UUID option from token selection in Keystone

 .../barclamp/keystone/_edit_attributes.html.haml   |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: d14b693e71c40fc9c3fb4afb9b468f042c086e1c

Crowbar-Release: pebbles
