### PR TITLE
Remove possibility to use sqlite

### DIFF
--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -31,7 +31,6 @@
         "pip://python-keystoneclient>=0.2,<0.3"
       ],
       "use_syslog": false,
-      "database_engine": "database",
       "database_instance": "none",
       "db": {
         "database": "keystone",

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -19,7 +19,6 @@
                     "use_virtualenv": { "type": "bool", "required": true },
                     "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "use_syslog": { "type": "bool", "required": true },
-                    "database_engine": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
                     "token_format": { "type": "str", "required": true },
                     "db": { "type": "map", "required": true, "mapping": {

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -39,7 +39,6 @@ locale_additions:
         edit_attributes: 
           attributes: Attributes
           frontend: Frontend
-          database_engine: Database Engine
           database_instance: Database Instance
           token_format: Algorithm for Token Generation
           default-tenant: Default Tenant

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -26,9 +26,7 @@ class KeystoneService < ServiceObject
 
   def proposal_dependencies(role)
     answer = []
-    if role.default_attributes[@bc_name]["database_engine"] == "database"
-      answer << { "barclamp" => "database", "inst" => role.default_attributes["keystone"]["database_instance"] }
-    end
+    answer << { "barclamp" => "database", "inst" => role.default_attributes["keystone"]["database_instance"] }
     if role.default_attributes[@bc_name]["use_gitrepo"]
       answer << { "barclamp" => "git", "inst" => role.default_attributes[@bc_name]["git_instance"] }
     end
@@ -52,20 +50,15 @@ class KeystoneService < ServiceObject
       end
       if dbs.empty?
         @logger.info("Keystone create_proposal: no database proposal found")
-        base["attributes"]["keystone"]["database_engine"] = ""
       else
         base["attributes"]["keystone"]["database_instance"] = dbs[0]
-        base["attributes"]["keystone"]["database_engine"] = "database"
         @logger.info("Keystone create_proposal: using database proposal: '#{dbs[0]}'")
       end
     rescue
       @logger.info("Keystone create_proposal: no database proposal found")
-      base["attributes"]["keystone"]["database_engine"] = ""
     end
 
-    # SQLite is not a fallback solution
-    # base["attributes"]["keystone"]["database_engine"] = "sqlite" if base["attributes"]["keystone"]["database_engine"] == ""
-    if base["attributes"]["keystone"]["database_engine"] == ""
+    if base["attributes"]["keystone"]["database_instance"] == ""
       raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "database"))
     end
     


### PR DESCRIPTION
It's known to be broken, and there was agreement to only use the
database barclamp.

This means we can remove the whole database_engine dance, which
simplifies things.

Note: changes in server.rb look big but are mostly indentation-related due to removal of an "if" statement.
