### PR TITLE
Add non-configurable attribute for http/https use in keystone [1/7]

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -30,6 +30,7 @@ default[:keystone][:db][:database] = "keystone"
 default[:keystone][:db][:user] = "keystone"
 default[:keystone][:db][:password] = "" # Set by Recipe
 
+default[:keystone][:api][:protocol] = "http"
 default[:keystone][:api][:service_port] = "5000"
 default[:keystone][:api][:service_host] = "0.0.0.0"
 default[:keystone][:api][:admin_port] = "35357"

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -317,8 +317,13 @@ end
 
 private
 def _build_connection(new_resource)
+  # Need to require net/https so that Net::HTTP gets monkey-patched
+  # to actually support SSL:
+  require 'net/https' if new_resource.protocol == "https"
+
   # Construct the http object
   http = Net::HTTP.new(new_resource.host, new_resource.port)
+  http.use_ssl = true if new_resource.protocol == "https"
 
   # Fill out the headers
   headers = _build_headers(new_resource.token)

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -242,6 +242,7 @@ pub_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "pub
 
 # Silly wake-up call - this is a hack
 keystone_register "wakeup keystone" do
+  protocol node[:keystone][:api][:protocol]
   host my_ipaddress
   port node[:keystone][:api][:admin_port]
   token node[:keystone][:service][:token]
@@ -254,6 +255,7 @@ end
   node[:keystone][:default][:tenant] 
 ].each do |tenant|
   keystone_register "add default #{tenant} tenant" do
+    protocol node[:keystone][:api][:protocol]
     host my_ipaddress
     port node[:keystone][:api][:admin_port]
     token node[:keystone][:service][:token]
@@ -267,6 +269,7 @@ end
   [ node[:keystone][:default][:username], node[:keystone][:default][:password], node[:keystone][:default][:tenant] ]
 ].each do |user_data|
   keystone_register "add default #{user_data[0]} user" do
+    protocol node[:keystone][:api][:protocol]
     host my_ipaddress
     port node[:keystone][:api][:admin_port]
     token node[:keystone][:service][:token]
@@ -282,6 +285,7 @@ end
 roles = %w[admin Member KeystoneAdmin KeystoneServiceAdmin sysadmin netadmin]
 roles.each do |role|
   keystone_register "add default #{role} role" do
+    protocol node[:keystone][:api][:protocol]
     host my_ipaddress
     port node[:keystone][:api][:admin_port]
     token node[:keystone][:service][:token]
@@ -302,6 +306,7 @@ user_roles = [
 ]
 user_roles.each do |args|
   keystone_register "add default #{args[2]}:#{args[0]} -> #{args[1]} role" do
+    protocol node[:keystone][:api][:protocol]
     host my_ipaddress
     port node[:keystone][:api][:admin_port]
     token node[:keystone][:service][:token]
@@ -321,6 +326,7 @@ ec2_creds = [
 ]
 ec2_creds.each do |args|
   keystone_register "add default ec2 creds for #{args[1]}:#{args[0]}" do
+    protocol node[:keystone][:api][:protocol]
     host my_ipaddress
     port node[:keystone][:api][:admin_port]
     token node[:keystone][:service][:token]
@@ -332,6 +338,7 @@ end
 
 # Create keystone service
 keystone_register "register keystone service" do
+  protocol node[:keystone][:api][:protocol]
   host my_ipaddress
   port node[:keystone][:api][:admin_port]
   token node[:keystone][:service][:token]
@@ -343,14 +350,15 @@ end
 
 # Create keystone endpoint
 keystone_register "register keystone service" do
+  protocol node[:keystone][:api][:protocol]
   host my_ipaddress
   port node[:keystone][:api][:admin_port]
   token node[:keystone][:service][:token]
   endpoint_service "keystone"
   endpoint_region "RegionOne"
-  endpoint_publicURL "http://#{pub_ipaddress}:#{node[:keystone][:api][:service_port]}/v2.0"
-  endpoint_adminURL "http://#{my_ipaddress}:#{node[:keystone][:api][:admin_port]}/v2.0"
-  endpoint_internalURL "http://#{my_ipaddress}:#{node[:keystone][:api][:service_port]}/v2.0"
+  endpoint_publicURL "#{node[:keystone][:api][:protocol]}://#{pub_ipaddress}:#{node[:keystone][:api][:service_port]}/v2.0"
+  endpoint_adminURL "#{node[:keystone][:api][:protocol]}://#{my_ipaddress}:#{node[:keystone][:api][:admin_port]}/v2.0"
+  endpoint_internalURL "#{node[:keystone][:api][:protocol]}://#{my_ipaddress}:#{node[:keystone][:api][:service_port]}/v2.0"
 #  endpoint_global true
 #  endpoint_enabled true
   action :add_endpoint_template

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -19,6 +19,7 @@
 
 actions :add_service, :add_endpoint_template, :add_tenant, :add_user, :add_role, :add_access, :add_ec2, :wakeup
 
+attribute :protocol, :kind_of => String
 attribute :host, :kind_of => String
 attribute :port, :kind_of => Integer
 attribute :token, :kind_of => String

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -52,6 +52,9 @@ min_pool_size = <%= @sql_min_pool_size %>
 max_pool_size = <%= @sql_max_pool_size %>
 pool_timeout = <%= @sql_pool_timeout %>
 
+[ssl]
+enable = False
+
 [signing]
 token_format = <%= @token_format %>
 #token_format = PKI #[PKI|UUID]


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
