### PR TITLE
Fix CHEF-3694 caused by bad resource naming

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -334,7 +334,7 @@ keystone_register "register keystone service" do
 end
 
 # Create keystone endpoint
-keystone_register "register keystone service" do
+keystone_register "register keystone endpoint" do
   protocol node[:keystone][:api][:protocol]
   host my_ipaddress
   port node[:keystone][:api][:admin_port]


### PR DESCRIPTION
Two resources have the same name, which leads to:

WARN: Cloning resource attributes for keystone_register[register keystone service] from prior resource (CHEF-3694)
WARN: Previous keystone_register[register keystone service]: /var/chef/cache/cookbooks/keystone/recipes/server.rb:340:in `from_file'
WARN: Current  keystone_register[register keystone service]: /var/chef/cache/cookbooks/keystone/recipes/server.rb:352:in`from_file'
