### PR TITLE
Rebase keystone.conf to Grizzly.

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -32,7 +32,6 @@ default[:keystone][:db][:password] = "" # Set by Recipe
 
 default[:keystone][:api][:protocol] = "http"
 default[:keystone][:api][:service_port] = "5000"
-default[:keystone][:api][:service_host] = "0.0.0.0"
 default[:keystone][:api][:admin_port] = "35357"
 default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_port] = "35357"
@@ -40,6 +39,3 @@ default[:keystone][:api][:api_host] = "0.0.0.0"
 
 
 default[:keystone][:sql][:idle_timeout] = 30
-default[:keystone][:sql][:min_pool_size] = 5
-default[:keystone][:sql][:max_pool_size] = 10
-default[:keystone][:sql][:pool_timeout] = 200

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -187,18 +187,13 @@ template "/etc/keystone/keystone.conf" do
     variables(
       :sql_connection => sql_connection,
       :sql_idle_timeout => node[:keystone][:sql][:idle_timeout],
-      :sql_min_pool_size => node[:keystone][:sql][:min_pool_size],
-      :sql_max_pool_size => node[:keystone][:sql][:max_pool_size],
-      :sql_pool_timeout => node[:keystone][:sql][:pool_timeout],
       :debug => node[:keystone][:debug],
       :verbose => node[:keystone][:verbose],
       :admin_token => node[:keystone][:service][:token],
-      :service_api_port => node[:keystone][:api][:service_port], # Compute port
-      :service_api_host => node[:keystone][:api][:service_host],
       :admin_api_port => node[:keystone][:api][:admin_port], # Auth port
       :admin_api_host => node[:keystone][:api][:admin_host],
+      :api_host => node[:keystone][:api][:api_host], # public host
       :api_port => node[:keystone][:api][:api_port], # public port
-      :api_host => node[:keystone][:api][:api_host],
       :use_syslog => node[:keystone][:use_syslog],
       :token_format => node[:keystone][:token_format],
       :frontend => node[:keystone][:frontend]

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1,75 +1,110 @@
 [DEFAULT]
-# Show more verbose log output (sets INFO log level output)
-verbose = <%= @verbose ? "True" : "False" %>
-
-# Show debugging output in logs (sets DEBUG log level output)
-debug = <%= @debug ? "True" : "False" %>
-
-# Log to this file. Make sure you do not set the same log
-# file for both the API and registry servers!
-log_dir = /var/log/keystone
-log_file = keystone.log
-
-# Host properties
-bind_host = <%= @admin_api_host %>
-# Address to bind the API server
-public_host = <%= @api_host %>
-# Address to bind the Admin API server
-admin_host = <%= @admin_api_host %>
-# Address to bind the API server
-compute_host = <%= @service_api_host %>
-
-# Port the bind the API server to
-public_port = <%= @api_port %>
-# Port the bind the Admin API server to
-admin_port = <%= @admin_api_port %>
-# Port the bind the Compute
-compute_port = 3000
-
-# Admin access token
+# A "shared secret" between keystone and other openstack services
 admin_token = <%= @admin_token %>
 
+# The IP address of the network interface to listen on
+bind_host = <%= @admin_api_host %>
 
-# ================= Syslog Options ============================
-# Send logs to syslog (/dev/log) instead of to file specified
-# by `log-file`
+# The port number which the public service listens on
+public_port = <%= @api_port %>
+
+# The port number which the public admin listens on
+admin_port = <%= @admin_api_port %>
+
+# The base endpoint URLs for keystone that are advertised to clients
+# (NOTE: this does NOT affect how keystone listens for connections)
+public_endpoint = <%= @protocol %>://<%= @api_host %>:<%= @api_port %>/
+admin_endpoint = <%= @protocol %>://<%= @admin_api_host %>:<%= @admin_api_port %>/
+
+# The port number which the OpenStack Compute service listens on
+# compute_port = 8774
+
+# Path to your policy definition containing identity actions
+# policy_file = policy.json
+
+# Rule to check if no matching policy definition is found
+# FIXME(dolph): This should really be defined as [policy] default_rule
+# policy_default_rule = admin_required
+
+# Role for migrating membership relationships
+# During a SQL upgrade, the following values will be used to create a new role
+# that will replace records in the user_tenant_membership table with explicit
+# role grants.  After migration, the member_role_id will be used in the API
+# add_user_to_project, and member_role_name will be ignored.
+# member_role_id = 9fe2ff9ee4384b1894a90878d3e92bab
+# member_role_name = _member_
+
+# === Logging Options ===
+# Print debugging output
+# (includes plaintext request logging, potentially including passwords)
+debug = <%= @debug ? "True" : "False" %>
+
+# Print more verbose output
+verbose = <%= @verbose ? "True" : "False" %>
+
+# Name of log file to output to. If not set, logging will go to stdout.
+log_file = keystone.log
+
+# The directory to keep log files in (will be prepended to --logfile)
+log_dir = /var/log/keystone
+
+# Use syslog for logging.
 use_syslog = <%= @use_syslog ? "True" : "False" %>
 
-# Facility to use. If unset defaults to LOG_USER.
-# syslog_log_facility = LOG_LOCAL0
+# syslog facility to receive log lines
+# syslog_log_facility = LOG_USER
 
+# If this option is specified, the logging configuration file specified is
+# used and overrides any other logging options specified. Please see the
+# Python logging module documentation for details on logging configuration
+# files.
+# log_config = logging.conf
+
+# A logging.Formatter log message format string which may use any of the
+# available logging.LogRecord attributes.
+# log_format = %(asctime)s %(levelname)8s [%(name)s] %(message)s
+
+# Format string for %(asctime)s in log records.
+# log_date_format = %Y-%m-%d %H:%M:%S
+
+# onready allows you to send a notification when the process is ready to serve
+# For example, to have it notify using systemd, one could set shell command:
+# onready = systemd-notify --ready
+# or a module with notify() method:
+# onready = keystone.common.systemd
 
 [sql]
-# SQLAlchemy connection string for the reference implementation registry
-# server. Any valid SQLAlchemy connection string is fine.
-# See: http://bit.ly/ideIpI
+# The SQLAlchemy connection string used to connect to the database
 connection = <%= @sql_connection %>
 
-# Period in seconds after which SQLAlchemy should reestablish its connection
-# to the database.
-#idle_timeout = <%= @sql_idle_timeout %>
-min_pool_size = <%= @sql_min_pool_size %>
-max_pool_size = <%= @sql_max_pool_size %>
-pool_timeout = <%= @sql_pool_timeout %>
-
-[ssl]
-enable = False
-
-[signing]
-token_format = <%= @token_format %>
-#token_format = PKI #[PKI|UUID]
-#certfile = /etc/keystone/ssl/certs/signing_cert.pem
-#keyfile = /etc/keystone/ssl/private/signing_key.pem
-#ca_certs = /etc/keystone/ssl/certs/ca.pem
-#key_size = 1024
-#valid_days = 3650
-#ca_password = None
+# the timeout before idle sql connections are reaped
+idle_timeout = <%= @sql_idle_timeout %>
 
 [identity]
 driver = keystone.identity.backends.sql.Identity
 
+# This references the domain to use for all Identity API v2 requests (which are
+# not aware of domains). A domain with this ID will be created for you by
+# keystone-manage db_sync in migration 008.  The domain referenced by this ID
+# cannot be deleted on the v3 API, to prevent accidentally breaking the v2 API.
+# There is nothing special about this domain, other than the fact that it must
+# exist to order to maintain support for your v2 clients.
+# default_domain_id = default
+
+[trust]
+# driver = keystone.trust.backends.sql.Trust
+
+# delegation and impersonation features can be optionally disabled
+# enabled = True
+
 [catalog]
+# dynamic, sql-based backend (supports API/CLI-based management commands)
 driver = keystone.catalog.backends.sql.Catalog
+
+# static, file-based backend (does *NOT* support any management commands)
+# driver = keystone.catalog.backends.templated.TemplatedCatalog
+
+# template_file = default_catalog.templates
 
 [token]
 <% if @frontend=='apache' -%>
@@ -78,11 +113,113 @@ driver = keystone.token.backends.sql.Token
 driver = keystone.token.backends.kvs.Token
 <% end -%>
 
+# Amount of time a token should remain valid (in seconds)
+# expiration = 86400
+
 [policy]
 driver = keystone.policy.backends.sql.Policy
 
 [ec2]
 driver = keystone.contrib.ec2.backends.sql.Ec2
+
+[ssl]
+enable = False
+#certfile = /etc/keystone/ssl/certs/keystone.pem
+#keyfile = /etc/keystone/ssl/private/keystonekey.pem
+#ca_certs = /etc/keystone/ssl/certs/ca.pem
+#cert_required = True
+
+[signing]
+token_format = <%= @token_format %>
+#certfile = /etc/keystone/ssl/certs/signing_cert.pem
+#keyfile = /etc/keystone/ssl/private/signing_key.pem
+#ca_certs = /etc/keystone/ssl/certs/ca.pem
+#key_size = 1024
+#valid_days = 3650
+#ca_password = None
+
+[ldap]
+# url = ldap://localhost
+# user = dc=Manager,dc=example,dc=com
+# password = None
+# suffix = cn=example,cn=com
+# use_dumb_member = False
+# allow_subtree_delete = False
+# dumb_member = cn=dumb,dc=example,dc=com
+
+# Maximum results per page; a value of zero ('0') disables paging (default)
+# page_size = 0
+
+# The LDAP dereferencing option for queries. This can be either 'never',
+# 'searching', 'always', 'finding' or 'default'. The 'default' option falls
+# back to using default dereferencing configured by your ldap.conf.
+# alias_dereferencing = default
+
+# The LDAP scope for queries, this can be either 'one'
+# (onelevel/singleLevel) or 'sub' (subtree/wholeSubtree)
+# query_scope = one
+
+# user_tree_dn = ou=Users,dc=example,dc=com
+# user_filter =
+# user_objectclass = inetOrgPerson
+# user_domain_id_attribute = businessCategory
+# user_id_attribute = cn
+# user_name_attribute = sn
+# user_mail_attribute = email
+# user_pass_attribute = userPassword
+# user_enabled_attribute = enabled
+# user_enabled_mask = 0
+# user_enabled_default = True
+# user_attribute_ignore = tenant_id,tenants
+# user_allow_create = True
+# user_allow_update = True
+# user_allow_delete = True
+# user_enabled_emulation = False
+# user_enabled_emulation_dn =
+
+# tenant_tree_dn = ou=Groups,dc=example,dc=com
+# tenant_filter =
+# tenant_objectclass = groupOfNames
+# tenant_domain_id_attribute = businessCategory
+# tenant_id_attribute = cn
+# tenant_member_attribute = member
+# tenant_name_attribute = ou
+# tenant_desc_attribute = desc
+# tenant_enabled_attribute = enabled
+# tenant_attribute_ignore =
+# tenant_allow_create = True
+# tenant_allow_update = True
+# tenant_allow_delete = True
+# tenant_enabled_emulation = False
+# tenant_enabled_emulation_dn =
+
+# role_tree_dn = ou=Roles,dc=example,dc=com
+# role_filter =
+# role_objectclass = organizationalRole
+# role_id_attribute = cn
+# role_name_attribute = ou
+# role_member_attribute = roleOccupant
+# role_attribute_ignore =
+# role_allow_create = True
+# role_allow_update = True
+# role_allow_delete = True
+
+# group_tree_dn =
+# group_filter =
+# group_objectclass = groupOfNames
+# group_id_attribute = cn
+# group_name_attribute = ou
+# group_member_attribute = member
+# group_desc_attribute = desc
+# group_attribute_ignore =
+# group_allow_create = True
+# group_allow_update = True
+# group_allow_delete = True
+
+[auth]
+methods = password,token
+password = keystone.auth.plugins.password.Password
+token = keystone.auth.plugins.token.Token
 
 [filter:debug]
 paste.filter_factory = keystone.common.wsgi:Debug.factory
@@ -114,11 +251,17 @@ paste.filter_factory = keystone.contrib.s3:S3Extension.factory
 [filter:url_normalize]
 paste.filter_factory = keystone.middleware:NormalizingFilter.factory
 
+[filter:sizelimit]
+paste.filter_factory = keystone.middleware:RequestBodySizeLimiter.factory
+
 [filter:stats_monitoring]
 paste.filter_factory = keystone.contrib.stats:StatsMiddleware.factory
 
 [filter:stats_reporting]
 paste.filter_factory = keystone.contrib.stats:StatsExtension.factory
+
+[filter:access_log]
+paste.filter_factory = keystone.contrib.access:AccessLogMiddleware.factory
 
 [app:public_service]
 paste.app_factory = keystone.service:public_app_factory
@@ -130,13 +273,13 @@ paste.app_factory = keystone.service:v3_app_factory
 paste.app_factory = keystone.service:admin_app_factory
 
 [pipeline:public_api]
-pipeline = stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug ec2_extension user_crud_extension public_service
+pipeline = access_log sizelimit stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug ec2_extension user_crud_extension public_service
 
 [pipeline:admin_api]
-pipeline = stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug stats_reporting ec2_extension s3_extension crud_extension admin_service
+pipeline = access_log sizelimit stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug stats_reporting ec2_extension s3_extension crud_extension admin_service
 
 [pipeline:api_v3]
-pipeline = stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug stats_reporting ec2_extension s3_extension service_v3
+pipeline = access_log sizelimit stats_monitoring url_normalize token_auth admin_token_auth xml_body json_body debug stats_reporting ec2_extension s3_extension service_v3
 
 [app:public_version_service]
 paste.app_factory = keystone.service:public_version_app_factory
@@ -145,10 +288,10 @@ paste.app_factory = keystone.service:public_version_app_factory
 paste.app_factory = keystone.service:admin_version_app_factory
 
 [pipeline:public_version_api]
-pipeline = stats_monitoring url_normalize xml_body public_version_service
+pipeline = access_log sizelimit stats_monitoring url_normalize xml_body public_version_service
 
 [pipeline:admin_version_api]
-pipeline = stats_monitoring url_normalize xml_body admin_version_service
+pipeline = access_log sizelimit stats_monitoring url_normalize xml_body admin_version_service
 
 [composite:main]
 use = egg:Paste#urlmap
@@ -161,4 +304,3 @@ use = egg:Paste#urlmap
 /v2.0 = admin_api
 /v3 = api_v3
 / = admin_version_api
-

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -37,14 +37,10 @@
         "user": "keystone"
       },
       "sql": {
-        "idle_timeout": 30,
-        "min_pool_size": 5,
-        "max_pool_size": 10,
-        "pool_timeout": 200
+        "idle_timeout": 30
       },
       "api": {
         "service_port": 5000,
-        "service_host": "0.0.0.0",
         "api_port": 5000,
         "api_host": "0.0.0.0",
         "admin_port": 35357,

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -27,16 +27,12 @@
                       "password": { "type" : "str" }
                     }},
                     "sql": { "type": "map", "required": true, "mapping": {
-                      "idle_timeout": { "type" : "int", "required" : true },
-                      "min_pool_size": { "type" : "int", "required" : true },
-                      "max_pool_size": { "type" : "int", "required" : true },
-                      "pool_timeout": { "type" : "int", "required" : true }
+                      "idle_timeout": { "type" : "int", "required" : true }
                     }},
                     "api": { "type": "map", "required": true, "mapping": {
                       "service_port": { "type" : "int", "required" : true },
                       "api_port": { "type" : "int", "required" : true },
                       "admin_port": { "type" : "int", "required" : true },
-                      "service_host": { "type" : "str", "required" : true },
                       "api_host": { "type" : "str", "required" : true },
                       "admin_host": { "type" : "str", "required" : true }
                     }},


### PR DESCRIPTION
Actually uncomment sql.idle_timeout. The following options where dropped
from keystone.conf: public_host, admin_host, compute_host, min_pool_size,
max_pool_size, pool_timeout.

Basis for further feature additions.
