### PR TITLE
 	Configurable cert locations for token signing

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -39,3 +39,8 @@ default[:keystone][:api][:api_host] = "0.0.0.0"
 
 
 default[:keystone][:sql][:idle_timeout] = 30
+
+default[:keystone][:signing][:token_format] = "PKI"
+default[:keystone][:signing][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
+default[:keystone][:signing][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
+default[:keystone][:signing][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -195,7 +195,10 @@ template "/etc/keystone/keystone.conf" do
       :api_host => node[:keystone][:api][:api_host], # public host
       :api_port => node[:keystone][:api][:api_port], # public port
       :use_syslog => node[:keystone][:use_syslog],
-      :token_format => node[:keystone][:token_format],
+      :signing_token_format => node[:keystone][:signing][:token_format],
+      :signing_certfile => node[:keystone][:signing][:certfile],
+      :signing_keyfile => node[:keystone][:signing][:keyfile],
+      :signing_ca_certs => node[:keystone][:signing][:ca_certs],
       :frontend => node[:keystone][:frontend]
     )
     if node[:keystone][:frontend]=='native'

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -130,10 +130,10 @@ enable = False
 #cert_required = True
 
 [signing]
-token_format = <%= @token_format %>
-#certfile = /etc/keystone/ssl/certs/signing_cert.pem
-#keyfile = /etc/keystone/ssl/private/signing_key.pem
-#ca_certs = /etc/keystone/ssl/certs/ca.pem
+token_format = <%= @signing_token_format %>
+certfile = <%= @signing_certfile %>
+keyfile = <%= @signing_keyfile %>
+ca_certs = <%= @signing_ca_certs %>
 #key_size = 1024
 #valid_days = 3650
 #ca_password = None

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -6,7 +6,6 @@
       "debug": false,
       "frontend": "apache",
       "verbose": false,
-      "token_format": "PKI",
       "gitrepo": "http://github.com/openstack/keystone.git",
       "git_instance": "",
       "git_refspec": "stable/grizzly",
@@ -59,6 +58,12 @@
         "tenant": "openstack",
         "username": "crowbar",
         "password": "crowbar"
+      },
+      "signing": {
+        "token_format": "PKI",
+        "certfile": "/etc/keystone/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/keystone/ssl/private/signing_key.pem",
+        "ca_certs": "/etc/keystone/ssl/certs/ca.pem"
       }
     }
   },

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -20,7 +20,6 @@
                     "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "use_syslog": { "type": "bool", "required": true },
                     "database_instance": { "type": "str", "required": true },
-                    "token_format": { "type": "str", "required": true },
                     "db": { "type": "map", "required": true, "mapping": {
                       "database": { "type" : "str", "required" : true },
                       "user": { "type" : "str", "required" : true },
@@ -49,6 +48,12 @@
                       "tenant": { "type" : "str", "required" : true },
                       "username": { "type" : "str", "required" : true },
                       "password": { "type" : "str", "required" : true }
+                    }},
+                    "signing" : { "type" : "map", "required" : true, "mapping": {
+                      "token_format": { "type": "str", "required": true },
+                      "certfile": { "type": "str" },
+                      "keyfile": { "type": "str" },
+                      "ca_certs": { "type": "str" }
                     }}
               }}
      }},

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -11,7 +11,7 @@
 
     %p
       %label{ :for => :token_format }= t('.token_format')
-      = select_tag :token_format, options_for_select([['PKI','PKI'], ['UUID', 'UUID']], @proposal.raw_data['attributes'][@proposal.barclamp]["token_format"].to_s), :onchange => "update_value('token_format', 'token_format', 'string')"
+      = select_tag :token_format, options_for_select([['PKI','PKI'], ['UUID', 'UUID']], @proposal.raw_data['attributes'][@proposal.barclamp]["signing"]["token_format"].to_s), :onchange => "update_value('signing/token_format', 'token_format', 'string')"
     %p
       %label{ :for => :default_tenant }= t('.default-tenant')
       %input#default_tenant{:type => "text", :name => "default_tenant", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["default"]["tenant"], :onchange => "update_value('default/tenant','default_tenant','string')"}


### PR DESCRIPTION
Otherwise cloud admins can't really provide their own certificates
without putting them into the default locations (and hoping that nobody
runs keystone-manage pki_setup).

Depends on https://github.com/crowbar/barclamp-keystone/pull/84, thus only looking at https://github.com/saschpe/barclamp-keystone/commit/6f328157548057f093b9a49a8f55c38cc6c2763d will be enough
