### PR TITLE
Stop creating KeystoneAdmin KeystoneServiceAdmin sysadmin netadmin roles

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -267,7 +267,8 @@ end
 
 
 # Create roles
-roles = %w[admin Member KeystoneAdmin KeystoneServiceAdmin sysadmin netadmin]
+## Member is used by horizon (see OPENSTACK_KEYSTONE_DEFAULT_ROLE option)
+roles = %w[admin Member]
 roles.each do |role|
   keystone_register "add default #{role} role" do
     protocol node[:keystone][:api][:protocol]
@@ -282,12 +283,8 @@ end
 # Create Access info
 user_roles = [ 
   [node[:keystone][:admin][:username], "admin", node[:keystone][:admin][:tenant]],
-  [node[:keystone][:admin][:username], "KeystoneAdmin", node[:keystone][:admin][:tenant]],
-  [node[:keystone][:admin][:username], "KeystoneServiceAdmin", node[:keystone][:admin][:tenant]],
   [node[:keystone][:admin][:username], "admin", node[:keystone][:default][:tenant]],
-  [node[:keystone][:default][:username], "Member", node[:keystone][:default][:tenant]],
-  [node[:keystone][:default][:username], "sysadmin", node[:keystone][:default][:tenant]],
-  [node[:keystone][:default][:username], "netadmin", node[:keystone][:default][:tenant]]
+  [node[:keystone][:default][:username], "Member", node[:keystone][:default][:tenant]]
 ]
 user_roles.each do |args|
   keystone_register "add default #{args[2]}:#{args[0]} -> #{args[1]} role" do


### PR DESCRIPTION
These roles have absolutely no use anymore since quite some time. And
they were dropped from the sample data in Grizzly:
https://github.com/openstack/keystone/commit/d6f7cbc484868bdec3eeb9d4b0f45b10ce536e79
