### PR TITLE
Register endpoints with public name and FQDN when possible

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -3,7 +3,7 @@
 admin_token = <%= @admin_token %>
 
 # The IP address of the network interface to listen on
-bind_host = <%= @admin_api_host %>
+bind_host = <%= @bind_admin_api_host %>
 
 # The port number which the public service listens on
 public_port = <%= @api_port %>


### PR DESCRIPTION
When using SSL, the common name field in the certificates is checked,
and using IP addresses won't work with that.

Internally to the OpenStack setup, it is always fine to use the FQDN
from the node, so we use this in the internal and admin URLs of the
endpoints.

For the public URL, we prefer to use the public name if it is set. If it
it not set, then we use the public FQDN only if SSL is enabled;
otherwise, we prefer the IP address (like before) because we're not 100%
sure that the administrator will have completed a proper DNS setup where
the public FQDN generated by Crowbar will be announced externally.
