### PR TITLE
Enable LDAP as a keystone backend (bnc#785470)

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -37,6 +37,7 @@ default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_port] = "35357"
 default[:keystone][:api][:api_host] = "0.0.0.0"
 
+default[:keystone][:identity][:driver] = "keystone.identity.backends.sql.Identity"
 
 default[:keystone][:sql][:idle_timeout] = 30
 
@@ -50,3 +51,87 @@ default[:keystone][:ssl][:certfile] = "/etc/keystone/ssl/certs/signing_cert.pem"
 default[:keystone][:ssl][:keyfile] = "/etc/keystone/ssl/private/signing_key.pem"
 default[:keystone][:ssl][:cert_required] = false
 default[:keystone][:ssl][:ca_certs] = "/etc/keystone/ssl/certs/ca.pem"
+
+default[:keystone][:ldap][:url] = "ldap://localhost"
+default[:keystone][:ldap][:user] = "dc=Manager,dc=example,dc=com"
+default[:keystone][:ldap][:password] = ""
+default[:keystone][:ldap][:suffix] = "cn=example,cn=com"
+default[:keystone][:ldap][:use_dumb_member] = false
+default[:keystone][:ldap][:allow_subtree_delete] = false
+default[:keystone][:ldap][:dumb_member] = "cn=dumb,dc=example,dc=com"
+default[:keystone][:ldap][:page_size] = 0
+default[:keystone][:ldap][:alias_dereferencing] = "default"
+default[:keystone][:ldap][:query_scope] = "one"
+
+default[:keystone][:ldap][:user_tree_dn] = ""
+default[:keystone][:ldap][:user_filter] = ""
+default[:keystone][:ldap][:user_objectclass] = 'inetOrgPerson'
+default[:keystone][:ldap][:user_id_attribute] = 'cn'
+default[:keystone][:ldap][:user_name_attribute] = 'sn'
+default[:keystone][:ldap][:user_mail_attribute] = 'email'
+default[:keystone][:ldap][:user_pass_attribute] = 'userPassword'
+default[:keystone][:ldap][:user_enabled_attribute] = 'enabled'
+default[:keystone][:ldap][:user_domain_id_attribute] = 'businessCategory'
+default[:keystone][:ldap][:user_enabled_mask] = 0
+default[:keystone][:ldap][:user_enabled_default] = 'true'
+default[:keystone][:ldap][:user_attribute_ignore] = 'tenant_id,tenants'
+default[:keystone][:ldap][:user_allow_create] = true
+default[:keystone][:ldap][:user_allow_update] = true
+default[:keystone][:ldap][:user_allow_delete] = true
+default[:keystone][:ldap][:user_enabled_emulation] = false
+default[:keystone][:ldap][:user_enabled_emulation_dn] = ""
+
+default[:keystone][:ldap][:tenant_tree_dn] = ""
+default[:keystone][:ldap][:tenant_filter] = ""
+default[:keystone][:ldap][:tenant_objectclass] = 'groupOfNames'
+default[:keystone][:ldap][:tenant_id_attribute] = 'cn'
+default[:keystone][:ldap][:tenant_member_attribute] = 'member'
+default[:keystone][:ldap][:tenant_name_attribute] = 'ou'
+default[:keystone][:ldap][:tenant_desc_attribute] = 'description'
+default[:keystone][:ldap][:tenant_enabled_attribute] = 'enabled'
+default[:keystone][:ldap][:tenant_domain_id_attribute] = 'businessCategory'
+default[:keystone][:ldap][:tenant_attribute_ignore] = ''
+default[:keystone][:ldap][:tenant_allow_create] = true
+default[:keystone][:ldap][:tenant_allow_update] = true
+default[:keystone][:ldap][:tenant_allow_delete] = true
+default[:keystone][:ldap][:tenant_enabled_emulation] = false
+default[:keystone][:ldap][:tenant_enabled_emulation_dn] = ""
+
+default[:keystone][:ldap][:role_tree_dn] = ""
+default[:keystone][:ldap][:role_filter] = ""
+default[:keystone][:ldap][:role_objectclass] = 'organizationalRole'
+default[:keystone][:ldap][:role_id_attribute] = 'cn'
+default[:keystone][:ldap][:role_name_attribute] = 'ou'
+default[:keystone][:ldap][:role_member_attribute] = 'roleOccupant'
+default[:keystone][:ldap][:role_attribute_ignore] = ''
+default[:keystone][:ldap][:role_allow_create] = true
+default[:keystone][:ldap][:role_allow_update] = true
+default[:keystone][:ldap][:role_allow_delete] = true
+
+default[:keystone][:ldap][:group_tree_dn] = ""
+default[:keystone][:ldap][:group_filter] = ""
+default[:keystone][:ldap][:group_objectclass] = 'groupOfNames'
+default[:keystone][:ldap][:group_id_attribute] = 'cn'
+default[:keystone][:ldap][:group_name_attribute] = 'ou'
+default[:keystone][:ldap][:group_member_attribute] = 'member'
+default[:keystone][:ldap][:group_desc_attribute] = 'description'
+# default[:keystone][:ldap][:group_domain_id_attribute] = 'businessCategory'
+default[:keystone][:ldap][:group_attribute_ignore] = ''
+default[:keystone][:ldap][:group_allow_create] = true
+default[:keystone][:ldap][:group_allow_update] = true
+default[:keystone][:ldap][:group_allow_delete] = true
+
+# default[:keystone][:ldap][:domain_tree_dn] = ""
+# default[:keystone][:ldap][:domain_filter] = ""
+# default[:keystone][:ldap][:domain_objectclass] = 'groupOfNames'
+# default[:keystone][:ldap][:domain_id_attribute] = 'cn'
+# default[:keystone][:ldap][:domain_name_attribute] = 'ou'
+# default[:keystone][:ldap][:domain_member_attribute] = 'member'
+# default[:keystone][:ldap][:domain_desc_attribute] = 'description'
+# default[:keystone][:ldap][:domain_enabled_attribute] = 'enabled'
+# default[:keystone][:ldap][:domain_attribute_ignore] = ''
+# default[:keystone][:ldap][:domain_allow_create] = true
+# default[:keystone][:ldap][:domain_allow_update] = true
+# default[:keystone][:ldap][:domain_allow_delete] = true
+# default[:keystone][:ldap][:domain_enabled_emulation] = false
+# default[:keystone][:ldap][:domain_enabled_emulation_dn] = ""

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -81,7 +81,7 @@ connection = <%= @sql_connection %>
 idle_timeout = <%= @sql_idle_timeout %>
 
 [identity]
-driver = keystone.identity.backends.sql.Identity
+driver = <%= node[:keystone][:identity][:driver] %>
 
 # This references the domain to use for all Identity API v2 requests (which are
 # not aware of domains). A domain with this ID will be created for you by
@@ -139,82 +139,85 @@ ca_certs = <%= @signing_ca_certs %>
 #ca_password = None
 
 [ldap]
-# url = ldap://localhost
-# user = dc=Manager,dc=example,dc=com
-# password = None
-# suffix = cn=example,cn=com
-# use_dumb_member = False
-# allow_subtree_delete = False
-# dumb_member = cn=dumb,dc=example,dc=com
+url = <%= node[:keystone][:ldap][:url] %>
+user = <%= node[:keystone][:ldap][:user] %>
+password =<%= node[:keystone][:ldap][:password] %>
+suffix = <%= node[:keystone][:ldap][:suffix] %>
+use_dumb_member = <%= node[:keystone][:ldap][:use_dumb_member] %>
+allow_subtree_delete = <%= node[:keystone][:ldap][:allow_subtree_delete] %>
+dumb_member = <%= node[:keystone][:ldap][:dumb_member] %>
 
 # Maximum results per page; a value of zero ('0') disables paging (default)
-# page_size = 0
+page_size = <%= node[:keystone][:ldap][:page_size] %>
 
 # The LDAP dereferencing option for queries. This can be either 'never',
 # 'searching', 'always', 'finding' or 'default'. The 'default' option falls
 # back to using default dereferencing configured by your ldap.conf.
-# alias_dereferencing = default
+alias_dereferencing = <%= node[:keystone][:ldap][:alias_dereferencing] %>
 
 # The LDAP scope for queries, this can be either 'one'
 # (onelevel/singleLevel) or 'sub' (subtree/wholeSubtree)
-# query_scope = one
+query_scope = <%= node[:keystone][:ldap][:query_scope] %>
 
 # user_tree_dn = ou=Users,dc=example,dc=com
-# user_filter =
-# user_objectclass = inetOrgPerson
-# user_domain_id_attribute = businessCategory
-# user_id_attribute = cn
-# user_name_attribute = sn
-# user_mail_attribute = email
-# user_pass_attribute = userPassword
-# user_enabled_attribute = enabled
-# user_enabled_mask = 0
-# user_enabled_default = True
-# user_attribute_ignore = tenant_id,tenants
-# user_allow_create = True
-# user_allow_update = True
-# user_allow_delete = True
-# user_enabled_emulation = False
-# user_enabled_emulation_dn =
+user_tree_dn = <%= node[:keystone][:ldap][:user_tree_dn] %>
+user_filter = <%= node[:keystone][:ldap][:user_filter] %>
+user_objectclass = <%= node[:keystone][:ldap][:user_objectclass] %>
+user_domain_id_attribute = <%= node[:keystone][:ldap][:user_domain_id_attribute] %>
+user_id_attribute = <%= node[:keystone][:ldap][:user_id_attribute] %>
+user_name_attribute = <%= node[:keystone][:ldap][:user_name_attribute] %>
+user_mail_attribute = <%= node[:keystone][:ldap][:user_mail_attribute] %>
+user_pass_attribute = <%= node[:keystone][:ldap][:user_pass_attribute] %>
+user_enabled_attribute = <%= node[:keystone][:ldap][:user_enabled_attribute] %>
+user_enabled_mask = <%= node[:keystone][:ldap][:user_enabled_mask] %>
+user_enabled_default = <%= node[:keystone][:ldap][:user_enabled_default] %>
+user_attribute_ignore = <%= node[:keystone][:ldap][:user_attribute_ignore] %>
+user_allow_create = <%= node[:keystone][:ldap][:user_allow_create] %>
+user_allow_update = <%= node[:keystone][:ldap][:user_allow_update] %>
+user_allow_delete = <%= node[:keystone][:ldap][:user_allow_delete] %>
+user_enabled_emulation = <%= node[:keystone][:ldap][:user_enabled_emulation] %>
+user_enabled_emulation_dn = <%= node[:keystone][:ldap][:user_enabled_emulation_dn] %>
 
-# tenant_tree_dn = ou=Groups,dc=example,dc=com
-# tenant_filter =
-# tenant_objectclass = groupOfNames
-# tenant_domain_id_attribute = businessCategory
-# tenant_id_attribute = cn
-# tenant_member_attribute = member
-# tenant_name_attribute = ou
-# tenant_desc_attribute = desc
-# tenant_enabled_attribute = enabled
-# tenant_attribute_ignore =
-# tenant_allow_create = True
-# tenant_allow_update = True
-# tenant_allow_delete = True
-# tenant_enabled_emulation = False
-# tenant_enabled_emulation_dn =
+# tenant_tree_dn = "ou=Groups,dc=example,dc=com"
+tenant_tree_dn = <%= node[:keystone][:ldap][:tenant_tree_dn] %>
+tenant_filter = <%= node[:keystone][:ldap][:tenant_filter] %>
+tenant_objectclass = <%= node[:keystone][:ldap][:tenant_objectclass] %>
+tenant_domain_id_attribute = <%= node[:keystone][:ldap][:tenant_domain_id_attribute] %>
+tenant_id_attribute = <%= node[:keystone][:ldap][:tenant_id_attribute] %>
+tenant_member_attribute = <%= node[:keystone][:ldap][:tenant_member_attribute] %>
+tenant_name_attribute = <%= node[:keystone][:ldap][:tenant_name_attribute] %>
+tenant_desc_attribute = <%= node[:keystone][:ldap][:tenant_desc_attribute] %>
+tenant_enabled_attribute = <%= node[:keystone][:ldap][:tenant_enabled_attribute] %>
+tenant_attribute_ignore = <%= node[:keystone][:ldap][:tenant_attribute_ignore] %>
+tenant_allow_create = <%= node[:keystone][:ldap][:tenant_allow_create] %>
+tenant_allow_update = <%= node[:keystone][:ldap][:tenant_allow_update] %>
+tenant_allow_delete = <%= node[:keystone][:ldap][:tenant_allow_delete] %>
+tenant_enabled_emulation = <%= node[:keystone][:ldap][:tenant_enabled_emulation] %>
+tenant_enabled_emulation_dn = <%= node[:keystone][:ldap][:tenant_enabled_emulation_dn] %>
 
 # role_tree_dn = ou=Roles,dc=example,dc=com
-# role_filter =
-# role_objectclass = organizationalRole
-# role_id_attribute = cn
-# role_name_attribute = ou
-# role_member_attribute = roleOccupant
-# role_attribute_ignore =
-# role_allow_create = True
-# role_allow_update = True
-# role_allow_delete = True
+role_tree_dn = <%= node[:keystone][:ldap][:role_tree_dn] %>
+role_filter = <%= node[:keystone][:ldap][:role_filter] %>
+role_objectclass = <%= node[:keystone][:ldap][:role_objectclass] %>
+role_id_attribute = <%= node[:keystone][:ldap][:role_id_attribute] %>
+role_name_attribute = <%= node[:keystone][:ldap][:role_name_attribute] %>
+role_member_attribute = <%= node[:keystone][:ldap][:role_allow_create] %>
+role_attribute_ignore = <%= node[:keystone][:ldap][:role_member_attribute] %>
+role_allow_create = <%= node[:keystone][:ldap][:role_attribute_ignore] %>
+role_allow_update = <%= node[:keystone][:ldap][:role_allow_update] %>
+role_allow_delete = <%= node[:keystone][:ldap][:role_allow_delete] %>
 
-# group_tree_dn =
-# group_filter =
-# group_objectclass = groupOfNames
-# group_id_attribute = cn
-# group_name_attribute = ou
-# group_member_attribute = member
-# group_desc_attribute = desc
-# group_attribute_ignore =
-# group_allow_create = True
-# group_allow_update = True
-# group_allow_delete = True
+group_tree_dn = <%= node[:keystone][:ldap][:group_tree_dn] %>
+group_filter = <%= node[:keystone][:ldap][:group_filter] %>
+group_objectclass = <%= node[:keystone][:ldap][:group_objectclass] %>
+group_id_attribute = <%= node[:keystone][:ldap][:group_id_attribute] %>
+group_name_attribute = <%= node[:keystone][:ldap][:group_name_attribute] %>
+group_member_attribute = <%= node[:keystone][:ldap][:group_member_attribute] %>
+group_desc_attribute = <%= node[:keystone][:ldap][:group_desc_attribute] %>
+group_attribute_ignore = <%= node[:keystone][:ldap][:group_attribute_ignore] %>
+group_allow_create = <%= node[:keystone][:ldap][:group_allow_create] %>
+group_allow_update = <%= node[:keystone][:ldap][:group_allow_update] %>
+group_allow_delete = <%= node[:keystone][:ldap][:group_allow_delete] %>
 
 [auth]
 methods = password,token


### PR DESCRIPTION
Therefore, changing the identity driver is necessary.  Templatize LDAP configuration in the chef recipe. There are too many values to present them in the UI in any meaningful way.
