### PR TITLE
Default charset for tempest

### DIFF
--- a/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
@@ -6,6 +6,7 @@ WSGIDaemonProcess keystone user=keystone group=nogroup processes=<%= @processes 
 
 Listen <%= @api_host %>:<%= @api_port %>
 <VirtualHost <%= @api_host %>:<%= @api_port %>>
+    AddDefaultCharset utf-8
     LogLevel warn
     ErrorLog ${APACHE_LOG_DIR}/keystone_error.log
 
@@ -15,6 +16,7 @@ Listen <%= @api_host %>:<%= @api_port %>
 
 Listen <%= @admin_api_host %>:<%= @admin_api_port %>
 <VirtualHost <%= @admin_api_host %>:<%= @admin_api_port %>>
+    AddDefaultCharset utf-8
     LogLevel warn
     ErrorLog ${APACHE_LOG_DIR}/keystone_error.log
 


### PR DESCRIPTION
https://github.com/openstack/tempest/blob/stable/grizzly/tempest/common/rest_client.py#L322
tempest expect content-type header with charset, so adding default charset into apache
