### PR TITLE
Default charset for tempest [1/1]

### DIFF
--- a/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/apache_keystone.conf.erb
@@ -6,6 +6,7 @@ WSGIDaemonProcess keystone user=keystone group=nogroup processes=<%= @processes 
 
 Listen <%= @api_host %>:<%= @api_port %>
 <VirtualHost <%= @api_host %>:<%= @api_port %>>
+    AddDefaultCharset utf-8
     LogLevel warn
     ErrorLog ${APACHE_LOG_DIR}/keystone_error.log
 
@@ -15,6 +16,7 @@ Listen <%= @api_host %>:<%= @api_port %>
 
 Listen <%= @admin_api_host %>:<%= @admin_api_port %>
 <VirtualHost <%= @admin_api_host %>:<%= @admin_api_port %>>
+    AddDefaultCharset utf-8
     LogLevel warn
     ErrorLog ${APACHE_LOG_DIR}/keystone_error.log
 


### PR DESCRIPTION
Tempest expects default charset in keystone apache responses in some tests (DE1384)

 .../templates/default/apache_keystone.conf.erb     |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: 2ee245e4b5e900cce73a321b909adf01959ba95d

Crowbar-Release: mesa-1.6
