### PR TITLE
keystone admin_port had wrong datatype in attributes/default.rb [1/1]

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -32,7 +32,7 @@ default[:keystone][:db][:password] = "" # Set by Recipe
 
 default[:keystone][:api][:protocol] = "http"
 default[:keystone][:api][:service_port] = "5000"
-default[:keystone][:api][:admin_port] = "35357"
+default[:keystone][:api][:admin_port] = 35357  #declared in resource as Integer
 default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_port] = "35357"
 default[:keystone][:api][:api_host] = "0.0.0.0"


### PR DESCRIPTION
Everywhere an attribute is defined, the datatype must match.  Especially if there's an LWRP that's delcaring expected datatype.

 chef/cookbooks/keystone/attributes/default.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: f7e292c57353708fd05e0a59ff33e30f868b4f3a

Crowbar-Release: pebbles
