### PR TITLE
Always use the SQL backend for tokens.

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -107,11 +107,7 @@ driver = keystone.catalog.backends.sql.Catalog
 # template_file = default_catalog.templates
 
 [token]
-<% if @frontend=='apache' -%>
 driver = keystone.token.backends.sql.Token
-<% elsif @frontend=='native' -%>
-driver = keystone.token.backends.kvs.Token
-<% end -%>
 
 # Amount of time a token should remain valid (in seconds)
 # expiration = 86400


### PR DESCRIPTION
The KVS has a number of drawbacks:
- Requires load balancer to persist connections to a single keystone
  server by token
- Memory will grow out of control until keystone server is restarted
-  At some point kvs lookups get very slow because there are millions of
-  keys in the dict.
- Process restart invalidates all tokens.

see e.g. https://bugs.launchpad.net/tripleo/+bug/1188301
