### PR TITLE
Havana repo updates to crowbar.yml files for the openstack barclamps [8/9]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -61,8 +61,8 @@ locale_additions:
 debs:
   ubuntu-12.04:
     repos:
-      - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/grizzly main
-      - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-proposed/grizzly main
+      - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/havana main
+      - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-proposed/havana main
   pkgs:
     - keystone
     - python-keystone
@@ -72,13 +72,15 @@ debs:
 rpms:
   centos-6.4:
     repos:
-      - rpm http://rdo.fedorapeople.org/openstack/openstack-grizzly/rdo-release-grizzly.rpm
-      # http://repos.fedorapeople.org/repos/openstack/openstack-grizzly/epel-6
+      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
+      #- rpm http://rdo.fedorapeople.org/openstack/openstack-havana/rdo-release-havana.rpm
+      # http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
       # http://mirror.us.leaseweb.net/epel/6/x86_64
       # http://rbel.frameos.org/stable/el6/x86_64
   redhat-6.4:
     repos:
-      - rpm http://rdo.fedorapeople.org/openstack/openstack-grizzly/rdo-release-grizzly.rpm
+      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
+      #- rpm http://rdo.fedorapeople.org/openstack/openstack-havana/rdo-release-havana.rpm
   pkgs:
     - openstack-keystone
     - python-keystone
@@ -87,4 +89,5 @@ rpms:
     - mod_wsgi
 
 git_repo:
-  - keystone https://github.com/openstack/keystone.git stable/grizzly
+  - keystone https://github.com/openstack/keystone.git milestone-proposed
+  # - keystone https://github.com/openstack/keystone.git stable/havana


### PR DESCRIPTION
Updated the crowbar.yml files for the openstack barclamps so that the crowbar-bar-cache could be updated with the latest havana packages

 crowbar.yml |   15 +++++++++------
 1 file changed, 9 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: 3bb4c6cc22881de90084cba6ee8a6f1664dffb8c

Crowbar-Release: roxy
