### PR TITLE
Revert commits breaking the choice of token format

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -126,7 +126,7 @@ ca_certs = <%= @ssl_ca_certs %>
 cert_required = <%= @ssl_cert_required %>
 
 [signing]
-#token_format = <%= @signing_token_format %>
+token_format = <%= @signing_token_format %>
 certfile = <%= @signing_certfile %>
 keyfile = <%= @signing_keyfile %>
 ca_certs = <%= @signing_ca_certs %>


### PR DESCRIPTION
A deprecated option doesn't mean a non-working option...
