### PR TITLE
Do not fail immediately if wakeup fails, retry instead

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -390,12 +390,15 @@ if node[:keystone][:api][:protocol] == 'https'
   end
 end
 
-# Silly wake-up call - this is a hack
+# Silly wake-up call - this is a hack; we use retries because the server was
+# just (re)started, and might not answer on the first try
 keystone_register "wakeup keystone" do
   protocol node[:keystone][:api][:protocol]
   host my_admin_host
   port node[:keystone][:api][:admin_port]
   token node[:keystone][:service][:token]
+  retries 5
+  retry_delay 10
   action :wakeup
 end
 


### PR DESCRIPTION
Since we restart keystone immediately and then do a wakeup call,
sometimes the wakeup call fails because it cannot connect to the server
yet.

To avoid that, we should just retry the wakeup.

https://bugzilla.novell.com/show_bug.cgi?id=859678
