### PR TITLE
Fix setting of users default tenant

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -401,7 +401,7 @@ def _build_user_object(user_name, password, tenant_id)
   svc_obj = Hash.new
   svc_obj.store("name", user_name)
   svc_obj.store("password", password)
-  svc_obj.store("tenant_id", tenant_id)
+  svc_obj.store("tenantId", tenant_id)
   svc_obj.store("enabled", true)
   ret = Hash.new
   ret.store("user", svc_obj)


### PR DESCRIPTION
Keystone v2.0 api expects tenantId to define the default
tenant, not tenant_id (which is the EC2 credential tenant)

(cherry picked from commit b9b20622fbc015bbab4209456c6e1c018fe3d512)
