### PR TITLE
Updated local copy of upstream identity cookbook [1/1]

### DIFF
--- a/chef/cookbooks/openstack-identity/.rubocop.yml
+++ b/chef/cookbooks/openstack-identity/.rubocop.yml
@@ -1,0 +1,28 @@
+AllCops:
+  Includes:
+    - metadata.rb
+    - Gemfile
+    - attributes/**
+    - libraries/**
+    - providers/**
+    - recipes/**
+    - resources/**
+    - spec/**
+
+Encoding:
+  Exclude:
+    - metadata.rb
+    - Gemfile
+
+LineLength:
+  Enabled: false
+
+WordArray:
+  MinSize: 3
+
+# TODO(galstom21)
+# The rescue exception statements in providers/**.rb need to be modified,
+# to rescue specific exceptions.
+RescueException:
+  Exclude:
+    - providers/register.rb

--- a/chef/cookbooks/openstack-identity/README.md
+++ b/chef/cookbooks/openstack-identity/README.md
@@ -244,6 +244,7 @@ Attributes
 * `openstack['identity']['users']` - Array of users to create in the keystone server
 TODO: Add DB2 support on other platforms
 * `openstack['identity']['platform']['db2_python_packages']` - Array of DB2 python packages, only available on redhat platform
+* `openstack['identity']['token']['expiration']` - Token validity time in seconds
 
 Testing
 =====

--- a/chef/cookbooks/openstack-identity/attributes/default.rb
+++ b/chef/cookbooks/openstack-identity/attributes/default.rb
@@ -38,8 +38,8 @@ default['openstack']['identity']['debug'] = 'False'
 default['openstack']['identity']['service_port'] = '5000'
 default['openstack']['identity']['admin_port'] = '35357'
 default['openstack']['identity']['region'] = 'RegionOne'
-
 default['openstack']['identity']['bind_interface'] = 'lo'
+default['openstack']['identity']['token']['expiration'] = '86400'
 
 # Logging stuff
 default['openstack']['identity']['syslog']['use'] = false

--- a/chef/cookbooks/openstack-identity/recipes/server.rb
+++ b/chef/cookbooks/openstack-identity/recipes/server.rb
@@ -116,7 +116,7 @@ ip_address = address_for node['openstack']['identity']['bind_interface']
 # If the search role is set, we search for memcache
 # servers via a Chef search. If not, we look at the
 # memcache.servers attribute.
-memcache_servers = ''#memcached_servers.join ','  # from openstack-common lib
+memcache_servers = memcached_servers.join ','  # from openstack-common lib
 
 uris = {
   'identity-admin' => identity_admin_endpoint.to_s.gsub('%25', '%'),
@@ -149,7 +149,8 @@ template '/etc/keystone/keystone.conf' do
     uris: uris,
     public_endpoint: public_endpoint,
     admin_endpoint: admin_endpoint,
-    ldap: node['openstack']['identity']['ldap']
+    ldap: node['openstack']['identity']['ldap'],
+    token_expiration: node['openstack']['identity']['token']['expiration']
   )
 
   notifies :restart, 'service[keystone]', :immediately
@@ -169,9 +170,9 @@ template '/etc/keystone/default_catalog.templates' do
 end
 
 # sync db after keystone.conf is generated
-#execute 'keystone-manage db_sync' do
-#  user node['openstack']['identity']['user']
-#  group node['openstack']['identity']['group']
+execute 'keystone-manage db_sync' do
+  user node['openstack']['identity']['user']
+  group node['openstack']['identity']['group']
 
-#  only_if { node['openstack']['db']['identity']['migrate'] }
-#end
+  only_if { node['openstack']['db']['identity']['migrate'] }
+end

--- a/chef/cookbooks/openstack-identity/spec/register_spec.rb
+++ b/chef/cookbooks/openstack-identity/spec/register_spec.rb
@@ -5,7 +5,7 @@ require_relative 'spec_helper'
 
 describe Chef::Provider::Execute do
   before do
-    @chef_run = ::ChefSpec::Runner.new ::OPENSUSE_OPTS
+    @chef_run = ::ChefSpec::Runner.new ::SUSE_OPTS
     @chef_run.converge 'openstack-identity::default'
     @node = @chef_run.node
     @node.set['openstack'] = {

--- a/chef/cookbooks/openstack-identity/spec/server-suse_spec.rb
+++ b/chef/cookbooks/openstack-identity/spec/server-suse_spec.rb
@@ -5,7 +5,7 @@ require_relative 'spec_helper'
 
 describe 'openstack-identity::server' do
   describe 'suse' do
-    let(:runner) { ChefSpec::Runner.new(OPENSUSE_OPTS) }
+    let(:runner) { ChefSpec::Runner.new(SUSE_OPTS) }
     let(:node) { runner.node }
     let(:chef_run) { runner.converge(described_recipe) }
 

--- a/chef/cookbooks/openstack-identity/spec/server_spec.rb
+++ b/chef/cookbooks/openstack-identity/spec/server_spec.rb
@@ -340,6 +340,11 @@ describe 'openstack-identity::server' do
           r = line_regexp('driver = keystone.token.backends.sql.Token')
           expect(chef_run).to render_file(path).with_content(r)
         end
+
+        it 'sets token expiration time' do
+          r = line_regexp('expiration = 86400')
+          expect(chef_run).to render_file(path).with_content(r)
+        end
       end
 
       describe '[policy] section' do

--- a/chef/cookbooks/openstack-identity/spec/spec_helper.rb
+++ b/chef/cookbooks/openstack-identity/spec/spec_helper.rb
@@ -5,9 +5,9 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 LOG_LEVEL = :fatal
-OPENSUSE_OPTS = {
-  platform: 'opensuse',
-  version: '12.3',
+SUSE_OPTS = {
+  platform: 'suse',
+  version: '11.03',
   log_level: LOG_LEVEL
 }
 REDHAT_OPTS = {

--- a/chef/cookbooks/openstack-identity/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/openstack-identity/templates/default/keystone.conf.erb
@@ -171,7 +171,7 @@ template_file = /etc/keystone/default_catalog.templates
 driver = keystone.token.backends.<%= node["openstack"]["identity"]["token"]["backend"] %>.Token
 provider = keystone.token.providers.<%= node["openstack"]["auth"]["strategy"] %>.Provider
 # Amount of time a token should remain valid (in seconds)
-expiration = 86400
+expiration = <%= node["openstack"]["identity"]["token"]["expiration"] %>
 
 [policy]
 driver = keystone.policy.backends.<%= node["openstack"]["identity"]["policy"]["backend"] %>.Policy


### PR DESCRIPTION
Updated local copy of upstream identity cookbook.

 chef/cookbooks/openstack-identity/.rubocop.yml     |   28 +++++++
 chef/cookbooks/openstack-identity/README.md        |    1 +
 .../openstack-identity/attributes/default.rb       |    2 +-
 .../cookbooks/openstack-identity/recipes/server.rb |   15 ++--
 .../openstack-identity/spec/register_spec.rb       |    2 +-
 .../spec/server-opensuse_spec.rb                   |   86 --------------------
 .../openstack-identity/spec/server-suse_spec.rb    |   86 ++++++++++++++++++++
 .../openstack-identity/spec/server_spec.rb         |    5 ++
 .../openstack-identity/spec/spec_helper.rb         |    6 +-
 .../templates/default/keystone.conf.erb            |    2 +-
 10 files changed, 134 insertions(+), 99 deletions(-)

Crowbar-Pull-ID: 38a7e8f1efe4485e8f9467204f30875c6a69b3eb

Crowbar-Release: development
