### PR TITLE
Reverting back the modified data_bag_secret_path in upstream cookbooks [2/3]

### DIFF
--- a/chef/cookbooks/keystone-custom/recipes/default.rb
+++ b/chef/cookbooks/keystone-custom/recipes/default.rb
@@ -18,4 +18,6 @@ node.default['openstack']['identity']['admin_user'] = node['crowbar_keystone']['
 node.default['openstack']['secrets']['openstack_bootstrap_token'] = node['crowbar_keystone']['secrets']['bootstrap_token']
 node.default['openstack']['db']['identity']['migrate'] = false
 node.default['openstack']['memcached_servers'] = ''
+node.default['openstack']['secret']['key_path'] = '/var/chef/data_bags/openstack_data_bag_secret'
+
 

--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -41,7 +41,7 @@ default['openstack']['auth']['validate_certs'] = true
 # routine that looks up the value of encrypted databag values. This routine
 # uses the secret key file located at the following location to decrypt the
 # values in the data bag.
-default['openstack']['secret']['key_path'] = '/var/chef/data_bags/openstack_data_bag_secret'
+default['openstack']['secret']['key_path'] = '/etc/chef/openstack_data_bag_secret'
 
 # The name of the encrypted data bag that stores service user passwords, with
 # each key in the data bag corresponding to a named OpenStack service, like


### PR DESCRIPTION
Reverting back the modified data_bag_secret_path in upstream cookbooks

 chef/cookbooks/keystone-custom/recipes/default.rb  |    2 ++
 .../openstack-common/attributes/default.rb         |    2 +-
 2 files changed, 3 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: a0419c014438165466745907a201e19875b4b2f0

Crowbar-Release: development
