### PR TITLE
Interm Berkshelf support [3/6]

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -1,2 +1,2 @@
-cookbook 'openstack-common', github: 'stackforge/cookbook-openstack-common'
-cookbook 'openstack-identity', github: 'stackforge/cookbook-openstack-identity'
+cookbook 'openstack-common', path: '../../openstack/chef-solo/cookbooks/openstack-common'
+cookbook 'openstack-identity', path: 'cookbooks/openstack-identity'

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -40,7 +40,7 @@ roles:
   - name: keystone-server
     jig: chef-solo
     requires:
-      - os-base
+      - openstack-base
 
 debs:
   ubuntu-12.04:

--- a/crowbar_engine/barclamp_keystone/app/models/barclamp_keystone/server.rb
+++ b/crowbar_engine/barclamp_keystone/app/models/barclamp_keystone/server.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class BarclampKeystone::Server < Role
+class BarclampKeystone::Server < BarclampChef::Role
   include BarclampOpenstack
 
 # Event triggers for node creation and destruction.

--- a/crowbar_engine/barclamp_keystone/barclamp_keystone.gemspec
+++ b/crowbar_engine/barclamp_keystone/barclamp_keystone.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "berkshelf"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
These changes get things to the point where there is a centralized
berkshelf so that we only need to check in 1 copy of the upstream cookbooks

 chef/Berksfile                                     |    4 ++--
 crowbar.yml                                        |    2 +-
 .../app/models/barclamp_keystone/server.rb         |    2 +-
 .../barclamp_keystone/barclamp_keystone.gemspec    |    1 +
 4 files changed, 5 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 651b5e8f8b7dd85967f4ecf104c8b44082568c45

Crowbar-Release: development
