### PR TITLE
Interm Berkshelf support [3/6]

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -1,2 +1,2 @@
-cookbook 'openstack-common', github: 'stackforge/cookbook-openstack-common'
-cookbook 'openstack-identity', github: 'stackforge/cookbook-openstack-identity'
+cookbook 'openstack-common', path: '../../openstack/chef-solo/cookbooks/openstack-common'
+cookbook 'openstack-identity', path: 'cookbooks/openstack-identity'

--- a/chef/roles/keystone-server.rb
+++ b/chef/roles/keystone-server.rb
@@ -1,8 +1,7 @@
 name "keystone-server"
 description "Keystone server"
 run_list(
-    "role[os-base]",
+    "role[openstack-base]",
     "recipe[keystone-custom]",
-    "recipe[openstack-identity::server]",
-    "recipe[openstack-identity::registration]"
+    "role[os-identity]"
 )

--- a/chef/roles/os-identity.rb
+++ b/chef/roles/os-identity.rb
@@ -1,0 +1,7 @@
+name "os-identity"
+description "Roll-up role for Identity"
+run_list(
+  "role[os-base]",
+  "recipe[openstack-identity::server]",
+  "recipe[openstack-identity::registration]"
+  )

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -40,11 +40,12 @@ roles:
   - name: keystone-server
     jig: chef-solo
     requires:
-      - os-base
+      - openstack-base
       - database-server
     wants-attribs:
       - name: database-v4addr
         at:  'crowbar/database/server/v4addr'
+
 debs:
   ubuntu-12.04:
     repos:

--- a/crowbar_engine/barclamp_keystone/app/models/barclamp_keystone/server.rb
+++ b/crowbar_engine/barclamp_keystone/app/models/barclamp_keystone/server.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class BarclampKeystone::Server < Role
+class BarclampKeystone::Server < BarclampChef::Role
   include BarclampOpenstack
 
 # Event triggers for node creation and destruction.

--- a/crowbar_engine/barclamp_keystone/barclamp_keystone.gemspec
+++ b/crowbar_engine/barclamp_keystone/barclamp_keystone.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "berkshelf"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
This set of pull request is the first in a series that implements
interm Berkshelf support.

Design:

This assumes that there is a berkshelf checked in to the openstack
barclamp.  This change will come in a separate pull request so as
to not muddy the waters.

When the user clicks the table cell to target a role to a node,
on_proposed is called on the role.  This causes "berks package"
to be called, which creates a package.tar.gz file that contains
all of the dependent cookbooks.  Note that this only happens
once for each role.

The chef-solo jig then scp's the package.tar.gz to the target
node, and unzips it.

All of this only occurs if there is a file named
Berksfile.central in the same directory as the Berksfile for
the barclamp, so it will not effect current operation.

Pull requests to come:
- pull request that checks in the berkshelf to the openstack bc
- pull request that adds a nasty hack to make appropriate dirs
  writeable so that "berks package" can work
- pull request that removes all of the unneeded copies of the
  dependent cookbooks

These pull requests do not address how the berkshelf is initially
created.  Discretion is the better part of valor, and the crowbar
team will address this as part of on-line mode.

 chef/Berksfile                                     |    4 ++--
 chef/roles/keystone-server.rb                      |    5 ++---
 chef/roles/os-identity.rb                          |    7 +++++++
 crowbar.yml                                        |    3 ++-
 .../app/models/barclamp_keystone/server.rb         |    2 +-
 .../barclamp_keystone/barclamp_keystone.gemspec    |    1 +
 6 files changed, 15 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: c883448c62c77b5d87ff5d0e991668b6e825ec1d

Crowbar-Release: development
