### PR TITLE
Nasty hack to let "berks package" work [2/4]

### DIFF
--- a/setup/add_write.install
+++ b/setup/add_write.install
@@ -1,0 +1,2 @@
+#!/bin/bash
+chown -R crowbar:crowbar $BC_PATH/chef-solo


### PR DESCRIPTION
Berkshelf support: This is a nasty hack to change the ownership of
the appropriate directories so that "berks package" can work.

 setup/add_write.install |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: c94c67a683417ab2a3b35a47ade37c99ab66c788

Crowbar-Release: development
