### PR TITLE
Restart keystone immediately on changes of keystone.conf

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -496,7 +496,7 @@ if node[:keystone][:frontend] == 'native'
     service_name node[:keystone][:service_name]
     supports :status => true, :start => true, :restart => true
     action [ :enable, :start ]
-    subscribes :restart, resources(:template => "/etc/keystone/keystone.conf")
+    subscribes :restart, resources(:template => "/etc/keystone/keystone.conf"), :immediately
   end
 end
 


### PR DESCRIPTION
This is required as we need to restart before the wakeup calls that come
just afterwards, and a delayed notification won't make this
happen.

https://bugzilla.novell.com/show_bug.cgi?id=869471
