### PR TITLE
Update db password migration script to remove node attributes

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/005_generate_db_password.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/005_generate_db_password.rb
@@ -1,9 +1,26 @@
 def upgrade ta, td, a, d
-  if a['db']['password'].nil? || a['db']['password'].empty?
-    # old proposals had passwords created in the cookbook
+  # Old proposals had passwords created in the cookbook, so we need to migrate
+  # them in the proposal and in the role. We use a class variable to set the
+  # same password in the proposal and in the role.
+  unless defined?(@@keystone_db_password)
     service = ServiceObject.new "fake-logger"
-    a['db']['password'] = service.random_password
+    @@keystone_db_password = service.random_password
   end
+
+  Chef::Search::Query.new.search(:node) do |node|
+    unless (node[:keystone][:db][:password] rescue nil).nil?
+      unless node[:keystone][:db][:password].empty?
+        @@keystone_db_password = node[:keystone][:db][:password]
+      end
+      node[:keystone][:db].delete('password')
+      node.save
+    end
+  end
+
+  if a['db']['password'].nil? || a['db']['password'].empty?
+    a['db']['password'] = @@keystone_db_password
+  end
+
   return a, d
 end
 


### PR DESCRIPTION
On update, we want to use the db password from the proposal / role, and
not the one that might have been generated on the node (through the
cookbook). As the password is a "normal" attribute on the node, but a
"default" attribute on the role, the old one from the node is used.
Which means we really need to remove it to get the new one used.
