### PR TITLE
Use new synchronization helpers to avoid races when deploying with HA

### DIFF
--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -36,6 +36,16 @@ end.run_action(:create)
 #  proposal_name = node[:keystone][:config][:environment]
 #  monitor_creds = node[:keystone][:admin]
 #
+#  # Wait for all nodes to reach this point so we know that all nodes will have
+#  # all the required packages installed before we create the pacemaker
+#  # resources
+#  crowbar_pacemaker_sync_mark "sync-keystone_before_ha"
+#
+#  # Avoid races when creating pacemaker resources
+#  # (as a side-effect, if starting the service also does the db migration,
+#  # then we will avoid races there too as pacemaker will start the service).
+#  crowbar_pacemaker_sync_mark "wait-keystone_ha_resources"
+#
 #  service_name = proposal_name + '-service'
 #  pacemaker_primitive service_name do
 #    agent node[:keystone][:ha][:agent]
@@ -54,4 +64,7 @@ end.run_action(:create)
 #    rsc service_name
 #    action :create
 #  end
+#
+#  crowbar_pacemaker_sync_mark "create-keystone_ha_resources"
+#
 #end


### PR DESCRIPTION
There are a number of possible races when deploying keystone for the
first time:
- when creating of the database / database user
- when finding the PKI info so it's the same on all nodes
- when registering the endpoint and creating users in keystone
