### PR TITLE
Make Keystone API's Region available

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -38,6 +38,7 @@ default[:keystone][:api][:admin_port] = 35357
 default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_host] = "0.0.0.0"
 default[:keystone][:api][:version] = "v2.0"
+default[:keystone][:api][:region] = "RegionOne"
 
 default[:keystone][:identity][:driver] = "keystone.identity.backends.sql.Identity"
 default[:keystone][:assignment][:driver] = "keystone.assignment.backends.sql.Assignment"

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -20,6 +20,7 @@ module KeystoneHelper
       "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || versioned_service_URL(node, public_host, node["keystone"]["api"]["service_port"]),
       "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || versioned_service_URL(node, node[:fqdn], node["keystone"]["api"]["service_port"]),
       "use_ssl" => use_ssl,
+      "endpoint_region" => node["keystone"]["api"]["region"],
       "insecure" => use_ssl && node[:keystone][:ssl][:insecure],
       "protocol" => node["keystone"]["api"]["protocol"],
       "public_url_host" => node[:keystone][:api][:public_URL_host] || public_host,

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -624,7 +624,7 @@ keystone_register "register keystone endpoint" do
   port node[:keystone][:api][:admin_port]
   token node[:keystone][:service][:token]
   endpoint_service "keystone"
-  endpoint_region "RegionOne"
+  endpoint_region      node[:keystone][:api][:region]
   endpoint_publicURL   node[:keystone][:api][:versioned_public_URL]
   endpoint_adminURL    node[:keystone][:api][:versioned_admin_URL]
   endpoint_internalURL node[:keystone][:api][:versioned_internal_URL]


### PR DESCRIPTION
Just in case. This makes it possible to refer to it
without hardcoding the Region Name.
