### PR TITLE
install .openrc in the keystone::server recipe

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -659,3 +659,13 @@ node[:keystone][:monitor] = {} if node[:keystone][:monitor].nil?
 node[:keystone][:monitor][:svcs] = [] if node[:keystone][:monitor][:svcs].nil?
 node[:keystone][:monitor][:svcs] << ["keystone"] if node[:keystone][:monitor][:svcs].empty?
 node.save
+
+template "/root/.openrc" do
+  source "openrc.erb"
+  owner "root"
+  group "root"
+  mode 0600
+  variables(
+    :keystone_settings => KeystoneHelper.keystone_settings(node)
+    )
+end

--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -1,0 +1,6 @@
+# OPENSTACK ENV VARIABLES
+export OS_USERNAME=<%= @keystone_settings['admin_user'] %>
+export OS_PASSWORD=<%= @keystone_settings['admin_password'] %>
+export OS_TENANT_NAME=<%= @keystone_settings['default_tenant'] %>
+export OS_AUTH_URL=<%= @keystone_settings['public_auth_url'] %>
+export OS_AUTH_STRATEGY=keystone


### PR DESCRIPTION
The .openrc file contains useful values for interacting with OpenStack via the
command line such as the keystone service's location and credentials.

This is being moved from the nova cookbook since there are no nova specific
entries in the file and keystone is higher up in the barclamp/cookbook
dependency chain.
