### PR TITLE
update keystone.conf to Icehouse

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1,432 +1,1325 @@
 [DEFAULT]
-# A "shared secret" between keystone and other openstack services
+#
+# Options defined in keystone
+#
+
+# A "shared secret" that can be used to bootstrap Keystone.
+# This "token" does not represent a user, and carries no
+# explicit authorization. To disable in production (highly
+# recommended), remove AdminTokenAuthMiddleware from your
+# paste application pipelines (for example, in keystone-
+# paste.ini). (string value)
 admin_token = <%= @admin_token %>
 
-# The IP address of the network interface to listen on
-bind_host = <%= @bind_host %>
+# The IP Address of the network interface to for the public
+# service to listen on. (string value)
+# Deprecated group/name - [DEFAULT]/bind_host
+public_bind_host = <%= @bind_host %>
 
-# The port number which the public service listens on
-public_port = <%= @bind_service_port %>
+# The IP Address of the network interface to for the admin
+# service to listen on. (string value)
+# Deprecated group/name - [DEFAULT]/bind_host
+admin_bind_host = <%= @bind_host %>
 
-# The port number which the public admin listens on
+# The port which the OpenStack Compute service listens on.
+# (integer value)
+#compute_port=8774
+
+# The port number which the admin service listens on. (integer
+# value)
 admin_port = <%= @bind_admin_port %>
 
-# The base endpoint URLs for keystone that are advertised to clients
-# (NOTE: this does NOT affect how keystone listens for connections)
+# The port number which the public service listens on
+# (integer value)
+public_port = <%= @bind_service_port %>
+
+# The base public endpoint URL for keystone that are
+# advertised to clients (NOTE: this does NOT affect how
+# keystone listens for connections) (string value).
+# Defaults to the base host URL of the request. Eg a
+# request to http://server:5000/v2.0/users will
+# default to http://server:5000. You should only need
+# to set this value if the base URL contains a path
+# (eg /prefix/v2.0) or the endpoint should be found on
+# a different server.
 public_endpoint = <%= @public_endpoint %>
+
+# The base admin endpoint URL for keystone that are advertised
+# to clients (NOTE: this does NOT affect how keystone listens
+# for connections) (string value).
+# Defaults to the base host URL of the request. Eg a
+# request to http://server:35357/v2.0/users will
+# default to http://server:35357. You should only need
+# to set this value if the base URL contains a path
+# (eg /prefix/v2.0) or the endpoint should be found on
+# a different server.
 admin_endpoint = <%= @admin_endpoint %>
 
-# The port number which the OpenStack Compute service listens on
-# compute_port = 8774
+# onready allows you to send a notification when the process
+# is ready to serve For example, to have it notify using
+# systemd, one could set shell command: "onready = systemd-
+# notify --ready" or a module with notify() method: "onready =
+# keystone.common.systemd". (string value)
+#onready=<None>
 
-# Path to your policy definition containing identity actions
-# policy_file = policy.json
+# enforced by optional sizelimit middleware
+# (keystone.middleware:RequestBodySizeLimiter). (integer
+# value)
+#max_request_body_size=114688
 
-# Rule to check if no matching policy definition is found
-# FIXME(dolph): This should really be defined as [policy] default_rule
-# policy_default_rule = admin_required
+# limit the sizes of user & tenant ID/names. (integer value)
+#max_param_size=64
 
-# Role for migrating membership relationships
-# During a SQL upgrade, the following values will be used to create a new role
-# that will replace records in the user_tenant_membership table with explicit
-# role grants.  After migration, the member_role_id will be used in the API
-# add_user_to_project, and member_role_name will be ignored.
-# member_role_id = 9fe2ff9ee4384b1894a90878d3e92bab
-# member_role_name = _member_
+# similar to max_param_size, but provides an exception for
+# token values. (integer value)
+#max_token_size=8192
 
-# enforced by optional sizelimit middleware (keystone.middleware:RequestBodySizeLimiter)
-# max_request_body_size = 114688
+# During a SQL upgrade member_role_id will be used to create a
+# new role that will replace records in the
+# user_tenant_membership table with explicit role grants.
+# After migration, the member_role_id will be used in the API
+# add_user_to_project. (string value)
+#member_role_id=9fe2ff9ee4384b1894a90878d3e92bab
 
-# limit the sizes of user & tenant ID/names
-# max_param_size = 64
+# During a SQL upgrade member_role_id will be used to create a
+# new role that will replace records in the
+# user_tenant_membership table with explicit role grants.
+# After migration, member_role_name will be ignored. (string
+# value)
+#member_role_name=_member_
 
-# similar to max_param_size, but provides an exception for token values
-# max_token_size = 8192
+# The value passed as the keyword "rounds" to passlib encrypt
+# method. (integer value)
+#crypt_strength=40000
 
-# === Logging Options ===
-# Print debugging output
-# (includes plaintext request logging, potentially including passwords)
+# Set this to True if you want to enable TCP_KEEPALIVE on
+# server sockets i.e. sockets used by the keystone wsgi server
+# for client connections. (boolean value)
+#tcp_keepalive=false
+
+# Sets the value of TCP_KEEPIDLE in seconds for each server
+# socket. Only applies if tcp_keepalive is True. Not supported
+# on OS X. (integer value)
+#tcp_keepidle=600
+
+# The maximum number of entities that will be returned in a
+# collection can be set with list_limit, with no limit set by
+# default. This global limit may be then overridden for a
+# specific driver, by specifying a list_limit in the
+# appropriate section (e.g. [assignment]). (integer value)
+#list_limit=<None>
+
+# Set this to false if you want to enable the ability for
+# user, group and project entities to be moved between domains
+# by updating their domain_id. Allowing such movement is not
+# recommended if the scope of a domain admin is being
+# restricted by use of an appropriate policy file (see
+# policy.v3cloudsample as an example). (boolean value)
+#domain_id_immutable=true
+
+#
+# Options defined in oslo.messaging
+#
+
+# Use durable queues in amqp. (boolean value)
+# Deprecated group/name - [DEFAULT]/rabbit_durable_queues
+#amqp_durable_queues=false
+
+# Auto-delete queues in amqp. (boolean value)
+#amqp_auto_delete=false
+
+# Size of RPC connection pool. (integer value)
+#rpc_conn_pool_size=30
+
+# Modules of exceptions that are permitted to be recreated
+# upon receiving exception data from an rpc call. (list value)
+#allowed_rpc_exception_modules=oslo.messaging.exceptions,nova.exception,cinder.exception,exceptions
+
+# Qpid broker hostname. (string value)
+#qpid_hostname=localhost
+
+# Qpid broker port. (integer value)
+#qpid_port=5672
+
+# Qpid HA cluster host:port pairs. (list value)
+#qpid_hosts=$qpid_hostname:$qpid_port
+
+# Username for Qpid connection. (string value)
+#qpid_username=
+
+# Password for Qpid connection. (string value)
+#qpid_password=
+
+# Space separated list of SASL mechanisms to use for auth.
+# (string value)
+#qpid_sasl_mechanisms=
+
+# Seconds between connection keepalive heartbeats. (integer
+# value)
+#qpid_heartbeat=60
+
+# Transport to use, either 'tcp' or 'ssl'. (string value)
+#qpid_protocol=tcp
+
+# Whether to disable the Nagle algorithm. (boolean value)
+#qpid_tcp_nodelay=true
+
+# The qpid topology version to use.  Version 1 is what was
+# originally used by impl_qpid.  Version 2 includes some
+# backwards-incompatible changes that allow broker federation
+# to work.  Users should update to version 2 when they are
+# able to take everything down, as it requires a clean break.
+# (integer value)
+#qpid_topology_version=1
+
+# SSL version to use (valid only if SSL enabled). valid values
+# are TLSv1, SSLv23 and SSLv3. SSLv2 may be available on some
+# distributions. (string value)
+#kombu_ssl_version=
+
+# SSL key file (valid only if SSL enabled). (string value)
+#kombu_ssl_keyfile=
+
+# SSL cert file (valid only if SSL enabled). (string value)
+#kombu_ssl_certfile=
+
+# SSL certification authority file (valid only if SSL
+# enabled). (string value)
+#kombu_ssl_ca_certs=
+
+# How long to wait before reconnecting in response to an AMQP
+# consumer cancel notification. (floating point value)
+#kombu_reconnect_delay=1.0
+
+# The RabbitMQ broker address where a single node is used.
+# (string value)
+#rabbit_host=localhost
+
+# The RabbitMQ broker port where a single node is used.
+# (integer value)
+#rabbit_port=5672
+
+# RabbitMQ HA cluster host:port pairs. (list value)
+#rabbit_hosts=$rabbit_host:$rabbit_port
+
+# Connect over SSL for RabbitMQ. (boolean value)
+#rabbit_use_ssl=false
+
+# The RabbitMQ userid. (string value)
+#rabbit_userid=guest
+
+# The RabbitMQ password. (string value)
+#rabbit_password=guest
+
+# the RabbitMQ login method (string value)
+#rabbit_login_method=AMQPLAIN
+
+# The RabbitMQ virtual host. (string value)
+#rabbit_virtual_host=/
+
+# How frequently to retry connecting with RabbitMQ. (integer
+# value)
+#rabbit_retry_interval=1
+
+# How long to backoff for between retries when connecting to
+# RabbitMQ. (integer value)
+#rabbit_retry_backoff=2
+
+# Maximum number of RabbitMQ connection retries. Default is 0
+# (infinite retry count). (integer value)
+#rabbit_max_retries=0
+
+# Use HA queues in RabbitMQ (x-ha-policy: all). If you change
+# this option, you must wipe the RabbitMQ database. (boolean
+# value)
+#rabbit_ha_queues=false
+
+# If passed, use a fake RabbitMQ provider. (boolean value)
+#fake_rabbit=false
+
+# ZeroMQ bind address. Should be a wildcard (*), an ethernet
+# interface, or IP. The "host" option should point or resolve
+# to this address. (string value)
+#rpc_zmq_bind_address=*
+
+# MatchMaker driver. (string value)
+#rpc_zmq_matchmaker=oslo.messaging._drivers.matchmaker.MatchMakerLocalhost
+
+# ZeroMQ receiver listening port. (integer value)
+#rpc_zmq_port=9501
+
+# Number of ZeroMQ contexts, defaults to 1. (integer value)
+#rpc_zmq_contexts=1
+
+# Maximum number of ingress messages to locally buffer per
+# topic. Default is unlimited. (integer value)
+#rpc_zmq_topic_backlog=<None>
+
+# Directory for holding IPC sockets. (string value)
+#rpc_zmq_ipc_dir=/var/run/openstack
+
+# Name of this node. Must be a valid hostname, FQDN, or IP
+# address. Must match "host" option, if running Nova. (string
+# value)
+#rpc_zmq_host=keystone
+
+# Seconds to wait before a cast expires (TTL). Only supported
+# by impl_zmq. (integer value)
+#rpc_cast_timeout=30
+
+# Heartbeat frequency. (integer value)
+#matchmaker_heartbeat_freq=300
+
+# Heartbeat time-to-live. (integer value)
+#matchmaker_heartbeat_ttl=600
+
+# Host to locate redis. (string value)
+#host=127.0.0.1
+
+# Use this port to connect to redis host. (integer value)
+#port=6379
+
+# Password for Redis server (optional). (string value)
+#password=<None>
+
+# Size of RPC greenthread pool. (integer value)
+#rpc_thread_pool_size=64
+
+# Driver or drivers to handle sending notifications. (multi
+# valued)
+#notification_driver=
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+#notification_topics=notifications
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout=60
+
+# A URL representing the messaging driver to use and its full
+# configuration. If not set, we fall back to the rpc_backend
+# option and driver specific configuration. (string value)
+#transport_url=<None>
+
+# The messaging driver to use, defaults to rabbit. Other
+# drivers include qpid and zmq. (string value)
+#rpc_backend=rabbit
+
+# The default exchange under which topics are scoped. May be
+# overridden by an exchange name specified in the
+# transport_url option. (string value)
+#control_exchange=openstack
+
+
+#
+# Options defined in keystone.notifications
+#
+
+# Default publisher_id for outgoing notifications (string
+# value)
+#default_publisher_id=<None>
+
+
+#
+# Options defined in keystone.middleware.ec2_token
+#
+
+# URL to get token from ec2 request. (string value)
+#keystone_ec2_url=http://localhost:5000/v2.0/ec2tokens
+
+# Required if EC2 server requires client certificate. (string
+# value)
+#keystone_ec2_keyfile=<None>
+
+# Client certificate key filename. Required if EC2 server
+# requires client certificate. (string value)
+#keystone_ec2_certfile=<None>
+
+# A PEM encoded certificate authority to use when verifying
+# HTTPS connections. Defaults to the system CAs. (string
+# value)
+#keystone_ec2_cafile=<None>
+
+# Disable SSL certificate verification. (boolean value)
+#keystone_ec2_insecure=false
+
+
+#
+# Options defined in keystone.openstack.common.eventlet_backdoor
+#
+
+# Enable eventlet backdoor.  Acceptable values are 0, <port>,
+# and <start>:<end>, where 0 results in listening on a random
+# tcp port number; <port> results in listening on the
+# specified port number (and not enabling backdoor if that
+# port is in use); and <start>:<end> results in listening on
+# the smallest unused port number within the specified range
+# of port numbers.  The chosen port is displayed in the
+# service's log file. (string value)
+#backdoor_port=<None>
+
+
+#
+# Options defined in keystone.openstack.common.lockutils
+#
+
+# Whether to disable inter-process locks (boolean value)
+#disable_process_locking=false
+
+# Directory to use for lock files. (string value)
+#lock_path=<None>
+
+
+#
+# Options defined in keystone.openstack.common.log
+#
+
+# Print debugging output (set logging level to DEBUG instead
+# of default WARNING level). (boolean value)
 debug = <%= @debug ? "True" : "False" %>
 
-# Print more verbose output
+# Print more verbose output (set logging level to INFO instead
+# of default WARNING level). (boolean value)
 verbose = <%= @verbose ? "True" : "False" %>
 
-# Name of log file to output to. If not set, logging will go to stdout.
+# Log output to standard error (boolean value)
+#use_stderr=true
+
+# Format string to use for log messages with context (string
+# value)
+#logging_context_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages without context
+# (string value)
+#logging_default_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Data to append to log format when level is DEBUG (string
+# value)
+#logging_debug_format_suffix=%(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format
+# (string value)
+#logging_exception_prefix=%(asctime)s.%(msecs)03d %(process)d TRACE %(name)s %(instance)s
+
+# List of logger=LEVEL pairs (list value)
+#default_log_levels=amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN
+
+# Publish error events (boolean value)
+#publish_errors=false
+
+# Make deprecations fatal (boolean value)
+#fatal_deprecations=false
+
+# If an instance is passed with the log message, format it
+# like this (string value)
+#instance_format="[instance: %(uuid)s] "
+
+# If an instance UUID is passed with the log message, format
+# it like this (string value)
+#instance_uuid_format="[instance: %(uuid)s] "
+
+# The name of logging configuration file. It does not disable
+# existing loggers, but just appends specified logging
+# configuration to any other existing logging options. Please
+# see the Python logging module documentation for details on
+# logging configuration files. (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append=<None>
+
+# DEPRECATED. A logging.Formatter log message format string
+# which may use any of the available logging.LogRecord
+# attributes. This option is deprecated.  Please use
+# logging_context_format_string and
+# logging_default_format_string instead. (string value)
+#log_format=<None>
+
+# Format string for %%(asctime)s in log records. Default:
+# %(default)s (string value)
+#log_date_format=%Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to output to. If no default is
+# set, logging will go to stdout. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
 log_file = keystone.log
 
-# The directory to keep log files in (will be prepended to --logfile)
+# (Optional) The base directory used for relative --log-file
+# paths (string value)
+# Deprecated group/name - [DEFAULT]/logdir
 log_dir = /var/log/keystone
 
-# Use syslog for logging.
+# Use syslog for logging. Existing syslog format is DEPRECATED
+# during I, and then will be changed in J to honor RFC5424
+# (boolean value)
 use_syslog = <%= @use_syslog ? "True" : "False" %>
 
-# syslog facility to receive log lines
-# syslog_log_facility = LOG_USER
+# (Optional) Use syslog rfc5424 format for logging. If
+# enabled, will add APP-NAME (RFC5424) before the MSG part of
+# the syslog message.  The old format without APP-NAME is
+# deprecated in I, and will be removed in J. (boolean value)
+#use_syslog_rfc_format=false
 
-# If this option is specified, the logging configuration file specified is
-# used and overrides any other logging options specified. Please see the
-# Python logging module documentation for details on logging configuration
-# files.
-# log_config = logging.conf
+# Syslog facility to receive log lines (string value)
+#syslog_log_facility=LOG_USER
 
-# A logging.Formatter log message format string which may use any of the
-# available logging.LogRecord attributes.
-# log_format = %(asctime)s %(levelname)8s [%(name)s] %(message)s
 
-# Format string for %(asctime)s in log records.
-# log_date_format = %Y-%m-%d %H:%M:%S
-
-# onready allows you to send a notification when the process is ready to serve
-# For example, to have it notify using systemd, one could set shell command:
-# onready = systemd-notify --ready
-# or a module with notify() method:
-# onready = keystone.common.systemd
-
-# === Notification Options ===
-
-# Notifications can be sent when users or projects are created, updated or
-# deleted. There are three methods of sending notifications: logging (via the
-# log_file directive), rpc (via a message queue) and no_op (no notifications
-# sent, the default)
-
-# notification_driver can be defined multiple times
-# Do nothing driver (the default)
-# notification_driver = keystone.openstack.common.notifier.no_op_notifier
-# Logging driver example (not enabled by default)
-# notification_driver = keystone.openstack.common.notifier.log_notifier
-# RPC driver example (not enabled by default)
-# notification_driver = keystone.openstack.common.notifier.rpc_notifier
-
-# Default notification level for outgoing notifications
-# default_notification_level = INFO
-
-# Default publisher_id for outgoing notifications; included in the payload.
-# default_publisher_id =
-
-# AMQP topics to publish to when using the RPC notification driver.
-# Multiple values can be specified by separating with commas.
-# The actual topic names will be %s.%(default_notification_level)s
-# notification_topics = notifications
-
-# === RPC Options ===
-
-# For Keystone, these options apply only when the RPC notification driver is
-# used.
-
-# The messaging module to use, defaults to kombu.
-# rpc_backend = keystone.openstack.common.rpc.impl_kombu
-
-# Size of RPC thread pool
-# rpc_thread_pool_size = 64
-
-# Size of RPC connection pool
-# rpc_conn_pool_size = 30
-
-# Seconds to wait for a response from call or multicall
-# rpc_response_timeout = 60
-
-# Seconds to wait before a cast expires (TTL). Only supported by impl_zmq.
-# rpc_cast_timeout = 30
-
-# Modules of exceptions that are permitted to be recreated upon receiving
-# exception data from an rpc call.
-# allowed_rpc_exception_modules = keystone.openstack.common.exception,nova.exception,cinder.exception,exceptions
-
-# If True, use a fake RabbitMQ provider
-# fake_rabbit = False
-
-# AMQP exchange to connect to if using RabbitMQ or Qpid
-# control_exchange = openstack
-
-[sql]
-# The SQLAlchemy connection string used to connect to the database
-connection = <%= @sql_connection %>
-
-# the timeout before idle sql connections are reaped
-idle_timeout = <%= @sql_idle_timeout %>
-
-[identity]
-driver = <%= node[:keystone][:identity][:driver] %>
-
-# This references the domain to use for all Identity API v2 requests (which are
-# not aware of domains). A domain with this ID will be created for you by
-# keystone-manage db_sync in migration 008.  The domain referenced by this ID
-# cannot be deleted on the v3 API, to prevent accidentally breaking the v2 API.
-# There is nothing special about this domain, other than the fact that it must
-# exist to order to maintain support for your v2 clients.
-# default_domain_id = default
 #
-# A subset (or all) of domains can have their own identity driver, each with
-# their own partial configuration file in a domain configuration directory.
-# Only values specific to the domain need to be placed in the domain specific
-# configuration file. This feature is disabled by default; set
-# domain_specific_drivers_enabled to True to enable.
-# domain_specific_drivers_enabled = False
-# domain_config_dir = /etc/keystone/domains
+# Options defined in keystone.openstack.common.policy
+#
 
-# Maximum supported length for user passwords; decrease to improve performance.
-# max_password_length = 4096
+# JSON file containing policy (string value)
+#policy_file=policy.json
 
-[credential]
-# driver = keystone.credential.backends.sql.Credential
+# Rule enforced when requested rule is not found (string
+# value)
+#policy_default_rule=default
 
-[trust]
-# driver = keystone.trust.backends.sql.Trust
 
-# delegation and impersonation features can be optionally disabled
-# enabled = True
+[assignment]
 
-[os_inherit]
-# role-assignment inheritance to projects from owning domain can be
-# optionally enabled
-# enabled = False
+#
+# Options defined in keystone
+#
+
+# Keystone Assignment backend driver. (string value)
+driver = <%= node[:keystone][:assignment][:driver] %>
+
+# Toggle for assignment caching. This has no effect unless
+# global caching is enabled. (boolean value)
+#caching=true
+
+# TTL (in seconds) to cache assignment data. This has no
+# effect unless global caching is enabled. (integer value)
+#cache_time=<None>
+
+# Maximum number of entities that will be returned in an
+# assignment collection. (integer value)
+#list_limit=<None>
+
+
+[auth]
+
+#
+# Options defined in keystone
+#
+
+# Default auth methods. (list value)
+#methods = external,password,token
+
+# The password auth plugin module. (string value)
+#password=keystone.auth.plugins.password.Password
+
+# The token auth plugin module. (string value)
+#token=keystone.auth.plugins.token.Token
+
+# The external (REMOTE_USER) auth plugin module. (string
+# value)
+#external=keystone.auth.plugins.external.DefaultDomain
+
+
+[cache]
+
+#
+# Options defined in keystone
+#
+
+# Prefix for building the configuration dictionary for the
+# cache region. This should not need to be changed unless
+# there is another dogpile.cache region with the same
+# configuration name. (string value)
+#config_prefix=cache.keystone
+
+# Default TTL, in seconds, for any cached item in the
+# dogpile.cache region. This applies to any cached method that
+# doesn't have an explicit cache expiration time defined for
+# it. (integer value)
+#expiration_time=600
+
+# Dogpile.cache backend module. It is recommended that
+# Memcache (dogpile.cache.memcache) or Redis
+# (dogpile.cache.redis) be used in production deployments.
+# Small workloads (single process) like devstack can use the
+# dogpile.cache.memory backend. (string value)
+#backend=keystone.common.cache.noop
+
+# Use a key-mangling function (sha1) to ensure fixed length
+# cache-keys. This is toggle-able for debugging purposes, it
+# is highly recommended to always leave this set to True.
+# (boolean value)
+#use_key_mangler=true
+
+# Arguments supplied to the backend module. Specify this
+# option once per argument to be passed to the dogpile.cache
+# backend. Example format: "<argname>:<value>". (multi valued)
+#backend_argument=
+
+# Proxy Classes to import that will affect the way the
+# dogpile.cache backend functions. See the dogpile.cache
+# documentation on changing-backend-behavior. Comma delimited
+# list e.g. my.dogpile.proxy.Class, my.dogpile.proxyClass2.
+# (list value)
+#proxies=
+
+# Global toggle for all caching using the should_cache_fn
+# mechanism. (boolean value)
+#enabled=false
+
+# Extra debugging from the cache backend (cache keys,
+# get/set/delete/etc calls) This is only really useful if you
+# need to see the specific cache-backend get/set/delete calls
+# with the keys/values.  Typically this should be left set to
+# False. (boolean value)
+#debug_cache_backend=false
+
 
 [catalog]
-# dynamic, sql-based backend (supports API/CLI-based management commands)
-driver = keystone.catalog.backends.sql.Catalog
 
-# static, file-based backend (does *NOT* support any management commands)
-# driver = keystone.catalog.backends.templated.TemplatedCatalog
+#
+# Options defined in keystone
+#
 
-# template_file = default_catalog.templates
+# Catalog template file name for use with the template catalog
+# backend. (string value)
+#template_file=default_catalog.templates
+
+# Keystone catalog backend driver. (string value)
+#driver=keystone.catalog.backends.sql.Catalog
+
+# Maximum number of entities that will be returned in a
+# catalog collection. (integer value)
+#list_limit=<None>
+
+
+[credential]
+
+#
+# Options defined in keystone
+#
+
+# Keystone Credential backend driver. (string value)
+#driver=keystone.credential.backends.sql.Credential
+
+
+[database]
+
+#
+# Options defined in keystone.openstack.common.db.options
+#
+
+# The file name to use with SQLite (string value)
+#sqlite_db=keystone.sqlite
+
+# If True, SQLite uses synchronous mode (boolean value)
+#sqlite_synchronous=true
+
+# The backend to use for db (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend=sqlalchemy
+
+# The SQLAlchemy connection string used to connect to the
+# database (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+connection = <%= @sql_connection %>
+
+# The SQL mode to be used for MySQL sessions. This option,
+# including the default, overrides any server-set SQL mode. To
+# use whatever SQL mode is set by the server configuration,
+# set this to no value. Example: mysql_sql_mode= (string
+# value)
+#mysql_sql_mode=TRADITIONAL
+
+# Timeout before idle sql connections are reaped (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_idle_timeout
+# Deprecated group/name - [DATABASE]/sql_idle_timeout
+# Deprecated group/name - [sql]/idle_timeout
+idle_timeout = <%= @sql_idle_timeout %>
+
+# Minimum number of SQL connections to keep open in a pool
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_min_pool_size
+# Deprecated group/name - [DATABASE]/sql_min_pool_size
+#min_pool_size=1
+
+# Maximum number of SQL connections to keep open in a pool
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_pool_size
+# Deprecated group/name - [DATABASE]/sql_max_pool_size
+#max_pool_size=<None>
+
+# Maximum db connection retries during startup. (setting -1
+# implies an infinite retry count) (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries=10
+
+# Interval between retries of opening a sql connection
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval=10
+
+# If set, use this value for max_overflow with sqlalchemy
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow=<None>
+
+# Verbosity of SQL debugging information. 0=None,
+# 100=Everything (integer value)
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug=0
+
+# Add python stack traces to SQL as comment strings (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace=false
+
+# If set, use this value for pool_timeout with sqlalchemy
+# (integer value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout=<None>
+
+# Enable the experimental use of database reconnect on
+# connection lost (boolean value)
+#use_db_reconnect=false
+
+# seconds between db connection retries (integer value)
+#db_retry_interval=1
+
+# Whether to increase interval between db connection retries,
+# up to db_max_retry_interval (boolean value)
+#db_inc_retry_interval=true
+
+# max seconds between db connection retries, if
+# db_inc_retry_interval is enabled (integer value)
+#db_max_retry_interval=10
+
+# maximum db connection retries before error is raised.
+# (setting -1 implies an infinite retry count) (integer value)
+#db_max_retries=20
+
+
+[ec2]
+
+#
+# Options defined in keystone
+#
+
+# Keystone EC2Credential backend driver. (string value)
+#driver=keystone.contrib.ec2.backends.kvs.Ec2
+
 
 [endpoint_filter]
-# extension for creating associations between project and endpoints in order to
-# provide a tailored catalog for project-scoped token requests.
-# driver = keystone.contrib.endpoint_filter.backends.sql.EndpointFilter
-# return_all_endpoints_if_no_filter = True
+
+#
+# Options defined in keystone
+#
+
+# Keystone Endpoint Filter backend driver (string value)
+#driver=keystone.contrib.endpoint_filter.backends.sql.EndpointFilter
+
+# Toggle to return all active endpoints if no filter exists.
+# (boolean value)
+#return_all_endpoints_if_no_filter=true
+
+
+[federation]
+
+#
+# Options defined in keystone
+#
+
+# Keystone Federation backend driver. (string value)
+#driver=keystone.contrib.federation.backends.sql.Federation
+
+# Value to be used when filtering assertion parameters from
+# the environment. (string value)
+#assertion_prefix=
+
+
+[identity]
+
+#
+# Options defined in keystone
+#
+
+# This references the domain to use for all Identity API v2
+# requests (which are not aware of domains). A domain with
+# this ID will be created for you by keystone-manage db_sync
+# in migration 008.  The domain referenced by this ID cannot
+# be deleted on the v3 API, to prevent accidentally breaking
+# the v2 API. There is nothing special about this domain,
+# other than the fact that it must exist to order to maintain
+# support for your v2 clients. (string value)
+#default_domain_id=default
+
+# A subset (or all) of domains can have their own identity
+# driver, each with their own partial configuration file in a
+# domain configuration directory. Only values specific to the
+# domain need to be placed in the domain specific
+# configuration file. This feature is disabled by default; set
+# to True to enable. (boolean value)
+#domain_specific_drivers_enabled=false
+
+# Path for Keystone to locate the domain specificidentity
+# configuration files if domain_specific_drivers_enabled is
+# set to true. (string value)
+#domain_config_dir=/etc/keystone/domains
+
+# Keystone Identity backend driver. (string value)
+driver = <%= node[:keystone][:identity][:driver] %>
+
+# Maximum supported length for user passwords; decrease to
+# improve performance. (integer value)
+#max_password_length=4096
+
+# Maximum number of entities that will be returned in an
+# identity collection. (integer value)
+#list_limit=<None>
+
+
+[kvs]
+
+#
+# Options defined in keystone
+#
+
+# Extra dogpile.cache backend modules to register with the
+# dogpile.cache library. (list value)
+#backends=
+
+# Prefix for building the configuration dictionary for the KVS
+# region. This should not need to be changed unless there is
+# another dogpile.cache region with the same configuration
+# name. (string value)
+#config_prefix=keystone.kvs
+
+# Toggle to disable using a key-mangling function to ensure
+# fixed length keys. This is toggle-able for debugging
+# purposes, it is highly recommended to always leave this set
+# to True. (boolean value)
+#enable_key_mangler=true
+
+# Default lock timeout for distributed locking. (integer
+# value)
+#default_lock_timeout=5
+
+
+[ldap]
+
+#
+# Options defined in keystone
+#
+
+# URL for connecting to the LDAP server. (string value)
+url = <%= node[:keystone][:ldap][:url] %>
+
+# User BindDN to query the LDAP server. (string value)
+user = <%= node[:keystone][:ldap][:user] %>
+
+# Password for the BindDN to query the LDAP server. (string
+# value)
+password =<%= node[:keystone][:ldap][:password] %>
+
+# LDAP server suffix (string value)
+suffix = <%= node[:keystone][:ldap][:suffix] %>
+
+# If true, will add a dummy member to groups. This is required
+# if the objectclass for groups requires the "member"
+# attribute. (boolean value)
+use_dumb_member = <%= node[:keystone][:ldap][:use_dumb_member] %>
+
+# DN of the "dummy member" to use when "use_dumb_member" is
+# enabled. (string value)
+dumb_member = <%= node[:keystone][:ldap][:dumb_member] %>
+
+# allow deleting subtrees. (boolean value)
+allow_subtree_delete = <%= node[:keystone][:ldap][:allow_subtree_delete] %>
+
+# The LDAP scope for queries, this can be either "one"
+# (onelevel/singleLevel) or "sub" (subtree/wholeSubtree).
+# (string value)
+query_scope = <%= node[:keystone][:ldap][:query_scope] %>
+
+# Maximum results per page; a value of zero ("0") disables
+# paging. (integer value)
+page_size = <%= node[:keystone][:ldap][:page_size] %>
+
+# The LDAP dereferencing option for queries. This can be
+# either "never", "searching", "always", "finding" or
+# "default". The "default" option falls back to using default
+# dereferencing configured by your ldap.conf. (string value)
+alias_dereferencing = <%= node[:keystone][:ldap][:alias_dereferencing] %>
+
+# Override the system's default referral chasing behavior for
+# queries. (boolean value)
+#chase_referrals=<None>
+
+# Search base for users. (string value)
+user_tree_dn = <%= node[:keystone][:ldap][:user_tree_dn] %>
+
+# LDAP search filter for users. (string value)
+user_filter = <%= node[:keystone][:ldap][:user_filter] %>
+
+# LDAP objectClass for users. (string value)
+user_objectclass = <%= node[:keystone][:ldap][:user_objectclass] %>
+
+# LDAP attribute mapped to user id. (string value)
+user_id_attribute = <%= node[:keystone][:ldap][:user_id_attribute] %>
+
+# LDAP attribute mapped to user name. (string value)
+user_name_attribute = <%= node[:keystone][:ldap][:user_name_attribute] %>
+
+# LDAP attribute mapped to user email. (string value)
+user_mail_attribute = <%= node[:keystone][:ldap][:user_mail_attribute] %>
+
+# LDAP attribute mapped to password. (string value)
+user_pass_attribute = <%= node[:keystone][:ldap][:user_pass_attribute] %>
+
+# LDAP attribute mapped to user enabled flag. (string value)
+user_enabled_attribute = <%= node[:keystone][:ldap][:user_enabled_attribute] %>
+
+# Bitmask integer to indicate the bit that the enabled value
+# is stored in if the LDAP server represents "enabled" as a
+# bit on an integer rather than a boolean. A value of "0"
+# indicates the mask is not used. If this is not set to "0"
+# the typical value is "2". This is typically used when
+# "user_enabled_attribute = userAccountControl". (integer
+# value)
+user_enabled_mask = <%= node[:keystone][:ldap][:user_enabled_mask] %>
+
+# Default value to enable users. This should match an
+# appropriate int value if the LDAP server uses non-boolean
+# (bitmask) values to indicate if a user is enabled or
+# disabled. If this is not set to "True"the typical value is
+# "512". This is typically used when "user_enabled_attribute =
+# userAccountControl". (string value)
+user_enabled_default = <%= node[:keystone][:ldap][:user_enabled_default] %>
+
+# List of attributes stripped off the user on update. (list
+# value)
+user_attribute_ignore = <%= node[:keystone][:ldap][:user_attribute_ignore] %>
+
+# LDAP attribute mapped to default_project_id for users.
+# (string value)
+user_default_project_id_attribute = <%= node[:keystone][:ldap][:user_default_project_id_attribute] %>
+
+# Allow user creation in LDAP backend. (boolean value)
+user_allow_create = <%= node[:keystone][:ldap][:user_allow_create] %>
+
+# Allow user updates in LDAP backend. (boolean value)
+user_allow_update = <%= node[:keystone][:ldap][:user_allow_update] %>
+
+# Allow user deletion in LDAP backend. (boolean value)
+user_allow_delete = <%= node[:keystone][:ldap][:user_allow_delete] %>
+
+# If True, Keystone uses an alternative method to determine if
+# a user is enabled or not by checking if they are a member of
+# the "user_enabled_emulation_dn" group. (boolean value)
+user_enabled_emulation = <%= node[:keystone][:ldap][:user_enabled_emulation] %>
+
+# DN of the group entry to hold enabled users when using
+# enabled emulation. (string value)
+user_enabled_emulation_dn = <%= node[:keystone][:ldap][:user_enabled_emulation_dn] %>
+
+# List of additional LDAP attributes used for mapping
+# Additional attribute mappings for users. Attribute mapping
+# format is <ldap_attr>:<user_attr>, where ldap_attr is the
+# attribute in the LDAP entry and user_attr is the Identity
+# API attribute. (list value)
+#user_additional_attribute_mapping=
+
+# Search base for projects (string value)
+tenant_tree_dn = <%= node[:keystone][:ldap][:tenant_tree_dn] %>
+
+# LDAP search filter for projects. (string value)
+tenant_filter = <%= node[:keystone][:ldap][:tenant_filter] %>
+
+# LDAP objectClass for projects. (string value)
+tenant_objectclass = <%= node[:keystone][:ldap][:tenant_objectclass] %>
+
+# LDAP attribute mapped to project id. (string value)
+tenant_id_attribute = <%= node[:keystone][:ldap][:tenant_id_attribute] %>
+
+# LDAP attribute mapped to project membership for user.
+# (string value)
+tenant_member_attribute = <%= node[:keystone][:ldap][:tenant_member_attribute] %>
+
+# LDAP attribute mapped to project name. (string value)
+tenant_name_attribute = <%= node[:keystone][:ldap][:tenant_name_attribute] %>
+
+# LDAP attribute mapped to project description. (string value)
+tenant_desc_attribute = <%= node[:keystone][:ldap][:tenant_desc_attribute] %>
+
+# LDAP attribute mapped to project enabled. (string value)
+tenant_enabled_attribute = <%= node[:keystone][:ldap][:tenant_enabled_attribute] %>
+
+# LDAP attribute mapped to project domain_id. (string value)
+tenant_domain_id_attribute = <%= node[:keystone][:ldap][:tenant_domain_id_attribute] %>
+
+# List of attributes stripped off the project on update. (list
+# value)
+tenant_attribute_ignore = <%= node[:keystone][:ldap][:tenant_attribute_ignore] %>
+
+# Allow tenant creation in LDAP backend. (boolean value)
+tenant_allow_create = <%= node[:keystone][:ldap][:tenant_allow_create] %>
+
+# Allow tenant update in LDAP backend. (boolean value)
+tenant_allow_update = <%= node[:keystone][:ldap][:tenant_allow_update] %>
+
+# Allow tenant deletion in LDAP backend. (boolean value)
+tenant_allow_delete = <%= node[:keystone][:ldap][:tenant_allow_delete] %>
+
+# If True, Keystone uses an alternative method to determine if
+# a project is enabled or not by checking if they are a member
+# of the "tenant_enabled_emulation_dn" group. (boolean value)
+tenant_enabled_emulation = <%= node[:keystone][:ldap][:tenant_enabled_emulation] %>
+
+# DN of the group entry to hold enabled projects when using
+# enabled emulation. (string value)
+tenant_enabled_emulation_dn = <%= node[:keystone][:ldap][:tenant_enabled_emulation_dn] %>
+
+# Additional attribute mappings for projects. Attribute
+# mapping format is <ldap_attr>:<user_attr>, where ldap_attr
+# is the attribute in the LDAP entry and user_attr is the
+# Identity API attribute. (list value)
+#tenant_additional_attribute_mapping=
+
+# Search base for roles. (string value)
+role_tree_dn = <%= node[:keystone][:ldap][:role_tree_dn] %>
+
+# LDAP search filter for roles. (string value)
+role_filter = <%= node[:keystone][:ldap][:role_filter] %>
+
+# LDAP objectClass for roles. (string value)
+role_objectclass = <%= node[:keystone][:ldap][:role_objectclass] %>
+
+# LDAP attribute mapped to role id. (string value)
+role_id_attribute = <%= node[:keystone][:ldap][:role_id_attribute] %>
+
+# LDAP attribute mapped to role name. (string value)
+role_name_attribute = <%= node[:keystone][:ldap][:role_name_attribute] %>
+
+# LDAP attribute mapped to role membership. (string value)
+role_member_attribute = <%= node[:keystone][:ldap][:role_member_attribute] %>
+
+# List of attributes stripped off the role on update. (list
+# value)
+role_attribute_ignore = <%= node[:keystone][:ldap][:role_attribute_ignore] %>
+
+# Allow role creation in LDAP backend. (boolean value)
+role_allow_create = <%= node[:keystone][:ldap][:role_allow_create] %>
+
+# Allow role update in LDAP backend. (boolean value)
+role_allow_update = <%= node[:keystone][:ldap][:role_allow_update] %>
+
+# Allow role deletion in LDAP backend. (boolean value)
+role_allow_delete = <%= node[:keystone][:ldap][:role_allow_delete] %>
+
+# Additional attribute mappings for roles. Attribute mapping
+# format is <ldap_attr>:<user_attr>, where ldap_attr is the
+# attribute in the LDAP entry and user_attr is the Identity
+# API attribute. (list value)
+#role_additional_attribute_mapping=
+
+# Search base for groups. (string value)
+group_tree_dn = <%= node[:keystone][:ldap][:group_tree_dn] %>
+
+# LDAP search filter for groups. (string value)
+group_filter = <%= node[:keystone][:ldap][:group_filter] %>
+
+# LDAP objectClass for groups. (string value)
+group_objectclass = <%= node[:keystone][:ldap][:group_objectclass] %>
+
+# LDAP attribute mapped to group id. (string value)
+group_id_attribute = <%= node[:keystone][:ldap][:group_id_attribute] %>
+
+# LDAP attribute mapped to group name. (string value)
+group_name_attribute = <%= node[:keystone][:ldap][:group_name_attribute]%>
+
+# LDAP attribute mapped to show group membership. (string
+# value)
+group_member_attribute = <%= node[:keystone][:ldap][:group_member_attribute] %>
+
+# LDAP attribute mapped to group description. (string value)
+group_desc_attribute = <%= node[:keystone][:ldap][:group_desc_attribute] %>
+
+# List of attributes stripped off the group on update. (list
+# value)
+group_attribute_ignore = <%= node[:keystone][:ldap][:group_attribute_ignore] %>
+
+# Allow group creation in LDAP backend. (boolean value)
+group_allow_create = <%= node[:keystone][:ldap][:group_allow_create] %>
+
+# Allow group update in LDAP backend. (boolean value)
+group_allow_update = <%= node[:keystone][:ldap][:group_allow_update] %>
+
+# Allow group deletion in LDAP backend. (boolean value)
+group_allow_delete = <%= node[:keystone][:ldap][:group_allow_delete] %>
+
+# Additional attribute mappings for groups. Attribute mapping
+# format is <ldap_attr>:<user_attr>, where ldap_attr is the
+# attribute in the LDAP entry and user_attr is the Identity
+# API attribute. (list value)
+#group_additional_attribute_mapping=
+
+# CA certificate file path for communicating with LDAP
+# servers. (string value)
+#tls_cacertfile=<None>
+
+# CA certificate directory path for communicating with LDAP
+# servers. (string value)
+#tls_cacertdir=<None>
+
+# Enable TLS for communicating with LDAP servers. (boolean
+# value)
+#use_tls=false
+
+# valid options for tls_req_cert are demand, never, and allow.
+# (string value)
+#tls_req_cert=demand
+
+
+[memcache]
+
+#
+# Options defined in keystone
+#
+
+# Memcache servers in the format of "host:port" (list value)
+#servers=localhost:11211
+
+# Number of compare-and-set attempts to make when using
+# compare-and-set in the token memcache back end. (integer
+# value)
+#max_compare_and_set_retry=16
+
+
+[oauth1]
+
+#
+# Options defined in keystone
+#
+
+# Keystone Credential backend driver. (string value)
+#driver=keystone.contrib.oauth1.backends.sql.OAuth1
+
+# Duration (in seconds) for the OAuth Request Token. (integer
+# value)
+#request_token_duration=28800
+
+# Duration (in seconds) for the OAuth Access Token. (integer
+# value)
+#access_token_duration=86400
+
+
+[os_inherit]
+
+#
+# Options defined in keystone
+#
+
+# role-assignment inheritance to projects from owning domain
+# can be optionally enabled. (boolean value)
+#enabled=false
+
+
+[paste_deploy]
+
+#
+# Options defined in keystone
+#
+
+# Name of the paste configuration file that defines the
+# available pipelines. (string value)
+#config_file=keystone-paste.ini
+
+
+[policy]
+
+#
+# Options defined in keystone
+#
+
+# Keystone Policy backend driver. (string value)
+#driver=keystone.policy.backends.sql.Policy
+
+# Maximum number of entities that will be returned in a policy
+# collection. (integer value)
+#list_limit=<None>
+
+
+[revoke]
+
+#
+# Options defined in keystone
+#
+
+# An implementation of the backend for persisting revocation
+# events. (string value)
+#driver=keystone.contrib.revoke.backends.kvs.Revoke
+
+# This value (calculated in seconds) is added to token
+# expiration before a revocation event may be removed from the
+# backend. (integer value)
+#expiration_buffer=1800
+
+# Toggle for revocation event cacheing. This has no effect
+# unless global caching is enabled. (boolean value)
+#caching=true
+
+
+[signing]
+
+#
+# Options defined in keystone
+#
+
+# Deprecated in favor of provider in the [token] section.
+# (string value)
+#token_format=<None>
+
+# Path of the certfile for token signing. (string value)
+certfile = <%= @signing_certfile %>
+
+# Path of the keyfile for token signing. (string value)
+keyfile = <%= @signing_keyfile %>
+
+# Path of the CA for token signing. (string value)
+ca_certs = <%= @signing_ca_certs %>
+
+# Path of the CA Key for token signing. (string value)
+#ca_key=/etc/keystone/ssl/private/cakey.pem
+
+# Key Size (in bits) for token signing cert (auto generated
+# certificate). (integer value)
+#key_size=2048
+
+# Day the token signing cert is valid for (auto generated
+# certificate). (integer value)
+#valid_days=3650
+
+# Certificate Subject (auto generated certificate) for token
+# signing. (string value)
+#cert_subject=/C=US/ST=Unset/L=Unset/O=Unset/CN=www.example.com
+
+
+[ssl]
+
+#
+# Options defined in keystone
+#
+
+# Toggle for SSL support on the keystone eventlet servers.
+# (boolean value)
+enable = <%= @ssl_enable %>
+
+# Path of the certfile for SSL. (string value)
+certfile = <%= @ssl_certfile %>
+
+# Path of the keyfile for SSL. (string value)
+keyfile = <%= @ssl_keyfile %>
+
+# Path of the ca cert file for SSL. (string value)
+ca_certs = <%= @ssl_ca_certs %>
+
+# Path of the CA key file for SSL. (string value)
+#ca_key=/etc/keystone/ssl/private/cakey.pem
+
+# Require client certificate. (boolean value)
+cert_required = <%= @ssl_cert_required %>
+
+# SSL Key Length (in bits) (auto generated certificate).
+# (integer value)
+#key_size=1024
+
+# Days the certificate is valid for once signed (auto
+# generated certificate). (integer value)
+#valid_days=3650
+
+# SSL Certificate Subject (auto generated certificate).
+# (string value)
+#cert_subject=/C=US/ST=Unset/L=Unset/O=Unset/CN=localhost
+
+
+[stats]
+
+#
+# Options defined in keystone
+#
+
+# Keystone stats backend driver. (string value)
+#driver=keystone.contrib.stats.backends.kvs.Stats
+
 
 [token]
-# Provides token persistence.
-driver = keystone.token.backends.sql.Token
 
-# Controls the token construction, validation, and revocation operations.
-# Core providers are keystone.token.providers.[pki|uuid].Provider
+#
+# Options defined in keystone
+#
 
+# External auth mechanisms that should add bind information to
+# token e.g. kerberos, x509. (list value)
+#bind=
+
+# Enforcement policy on tokens presented to keystone with bind
+# information. One of disabled, permissive, strict, required
+# or a specifically required bind mode e.g. kerberos or x509
+# to require binding to that authentication. (string value)
+#enforce_token_bind=permissive
+
+# Amount of time a token should remain valid (in seconds).
+# (integer value)
+#expiration=3600
+
+# Controls the token construction, validation, and revocation
+# operations. Core providers are
+# "keystone.token.providers.[pki|uuid].Provider". (string
+# value)
 <% if @signing_token_format == "PKI" %>
 provider = keystone.token.providers.pki.Provider
 <% else %>
 provider = keystone.token.providers.uuid.Provider
 <%end %>
 
-# Amount of time a token should remain valid (in seconds)
-# expiration = 86400
+# Keystone Token persistence backend driver. (string value)
+#driver=keystone.token.backends.sql.Token
 
-# External auth mechanisms that should add bind information to token.
-# eg kerberos, x509
-# bind =
+# Toggle for token system cacheing. This has no effect unless
+# global caching is enabled. (boolean value)
+#caching=true
 
-# Enforcement policy on tokens presented to keystone with bind information.
-# One of disabled, permissive, strict, required or a specifically required bind
-# mode e.g. kerberos or x509 to require binding to that authentication.
-# enforce_token_bind = permissive
+# Time to cache the revocation list and the revocation events
+# if revoke extension is enabled (in seconds). This has no
+# effect unless global and token caching are enabled. (integer
+# value)
+#revocation_cache_time=3600
 
-# Token specific caching toggle. This has no effect unless the global caching
-# option is set to True
-# caching = True
+# Time to cache tokens (in seconds). This has no effect unless
+# global and token caching are enabled. (integer value)
+#cache_time=<None>
 
-# Token specific cache time-to-live (TTL) in seconds.
-# cache_time =
+# Revoke token by token identifier.  Setting revoke_by_id to
+# True enables various forms of enumerating tokens, e.g. `list
+# tokens for user`.  These enumerations are processed to
+# determine the list of tokens to revoke.   Only disable if
+# you are switching to using the Revoke extension with a
+# backend other than KVS, which stores events in memory.
+# (boolean value)
+#revoke_by_id=true
 
-# Revocation-List specific cache time-to-live (TTL) in seconds.
-# revocation_cache_time = 3600
 
-[cache]
-# Global cache functionality toggle.
-# enabled = False
+[trust]
 
-# Prefix for building the configuration dictionary for the cache region. This
-# should not need to be changed unless there is another dogpile.cache region
-# with the same configuration name
-# config_prefix = cache.keystone
-
-# Default TTL, in seconds, for any cached item in the dogpile.cache region.
-# This applies to any cached method that doesn't have an explicit cache
-# expiration time defined for it.
-# expiration_time = 600
-
-# Dogpile.cache backend module. It is recommended that Memcache
-# (dogpile.cache.memcache) or Redis (dogpile.cache.redis) be used in production
-# deployments.  Small workloads (single process) like devstack can use the
-# dogpile.cache.memory backend.
-# backend = keystone.common.cache.noop
-
-# Arguments supplied to the backend module. Specify this option once per
-# argument to be passed to the dogpile.cache backend.
-# Example format: <argname>:<value>
-# backend_argument =
-
-# Proxy Classes to import that will affect the way the dogpile.cache backend
-# functions.  See the dogpile.cache documentation on changing-backend-behavior.
-# Comma delimited list e.g. my.dogpile.proxy.Class, my.dogpile.proxyClass2
-# proxies =
-
-# Use a key-mangling function (sha1) to ensure fixed length cache-keys. This
-# is toggle-able for debugging purposes, it is highly recommended to always
-# leave this set to True.
-# use_key_mangler = True
-
-# Extra debugging from the cache backend (cache keys, get/set/delete/etc calls)
-# This is only really useful if you need to see the specific cache-backend
-# get/set/delete calls with the keys/values.  Typically this should be left
-# set to False.
-# debug_cache_backend = False
-
-[policy]
-driver = keystone.policy.backends.sql.Policy
-
-[ec2]
-driver = keystone.contrib.ec2.backends.sql.Ec2
-
-[assignment]
-driver = <%= node[:keystone][:assignment][:driver] %>
-
-# Assignment specific caching toggle. This has no effect unless the global
-# caching option is set to True
-# caching = True
-
-# Assignment specific cache time-to-live (TTL) in seconds.
-# cache_time =
-
-[oauth1]
-# driver = keystone.contrib.oauth1.backends.sql.OAuth1
-
-# The Identity service may include expire attributes.
-# If no such attribute is included, then the token lasts indefinitely.
-# Specify how quickly the request token will expire (in seconds)
-# request_token_duration = 28800
-# Specify how quickly the access token will expire (in seconds)
-# access_token_duration = 86400
-
-[ssl]
-enable = <%= @ssl_enable %>
-certfile = <%= @ssl_certfile %>
-keyfile = <%= @ssl_keyfile %>
-ca_certs = <%= @ssl_ca_certs %>
-cert_required = <%= @ssl_cert_required %>
-#key_size = 1024
-#valid_days = 3650
-#cert_required = False
-#cert_subject = /C=US/ST=Unset/L=Unset/O=Unset/CN=localhost
-
-[signing]
-# Deprecated in favor of provider in the [token] section
-# Allowed values are PKI or UUID
-# token_format =
-
-certfile = <%= @signing_certfile %>
-keyfile = <%= @signing_keyfile %>
-ca_certs = <%= @signing_ca_certs %>
-#ca_key = /etc/keystone/pki/private/cakey.pem
-#key_size = 2048
-#valid_days = 3650
-#cert_subject = /C=US/ST=Unset/L=Unset/O=Unset/CN=www.example.com
-
-[ldap]
-url = <%= node[:keystone][:ldap][:url] %>
-user = <%= node[:keystone][:ldap][:user] %>
-password =<%= node[:keystone][:ldap][:password] %>
-suffix = <%= node[:keystone][:ldap][:suffix] %>
-use_dumb_member = <%= node[:keystone][:ldap][:use_dumb_member] %>
-allow_subtree_delete = <%= node[:keystone][:ldap][:allow_subtree_delete] %>
-dumb_member = <%= node[:keystone][:ldap][:dumb_member] %>
-
-# Maximum results per page; a value of zero ('0') disables paging (default)
-page_size = <%= node[:keystone][:ldap][:page_size] %>
-
-# The LDAP dereferencing option for queries. This can be either 'never',
-# 'searching', 'always', 'finding' or 'default'. The 'default' option falls
-# back to using default dereferencing configured by your ldap.conf.
-alias_dereferencing = <%= node[:keystone][:ldap][:alias_dereferencing] %>
-
-# The LDAP scope for queries, this can be either 'one'
-# (onelevel/singleLevel) or 'sub' (subtree/wholeSubtree)
-query_scope = <%= node[:keystone][:ldap][:query_scope] %>
-
-user_tree_dn = <%= node[:keystone][:ldap][:user_tree_dn] %>
-user_filter = <%= node[:keystone][:ldap][:user_filter] %>
-user_objectclass = <%= node[:keystone][:ldap][:user_objectclass] %>
-user_id_attribute = <%= node[:keystone][:ldap][:user_id_attribute] %>
-user_name_attribute = <%= node[:keystone][:ldap][:user_name_attribute] %>
-user_mail_attribute = <%= node[:keystone][:ldap][:user_mail_attribute] %>
-user_pass_attribute = <%= node[:keystone][:ldap][:user_pass_attribute] %>
-user_enabled_attribute = <%= node[:keystone][:ldap][:user_enabled_attribute] %>
-user_enabled_mask = <%= node[:keystone][:ldap][:user_enabled_mask] %>
-user_enabled_default = <%= node[:keystone][:ldap][:user_enabled_default] %>
-user_attribute_ignore = <%= node[:keystone][:ldap][:user_attribute_ignore] %>
-user_default_project_id_attribute = <%= node[:keystone][:ldap][:user_default_project_id_attribute] %>
-user_allow_create = <%= node[:keystone][:ldap][:user_allow_create] %>
-user_allow_update = <%= node[:keystone][:ldap][:user_allow_update] %>
-user_allow_delete = <%= node[:keystone][:ldap][:user_allow_delete] %>
-user_enabled_emulation = <%= node[:keystone][:ldap][:user_enabled_emulation] %>
-user_enabled_emulation_dn = <%= node[:keystone][:ldap][:user_enabled_emulation_dn] %>
-
-tenant_tree_dn = <%= node[:keystone][:ldap][:tenant_tree_dn] %>
-tenant_filter = <%= node[:keystone][:ldap][:tenant_filter] %>
-tenant_objectclass = <%= node[:keystone][:ldap][:tenant_objectclass] %>
-tenant_domain_id_attribute = <%= node[:keystone][:ldap][:tenant_domain_id_attribute] %>
-tenant_id_attribute = <%= node[:keystone][:ldap][:tenant_id_attribute] %>
-tenant_member_attribute = <%= node[:keystone][:ldap][:tenant_member_attribute] %>
-tenant_name_attribute = <%= node[:keystone][:ldap][:tenant_name_attribute] %>
-tenant_desc_attribute = <%= node[:keystone][:ldap][:tenant_desc_attribute] %>
-tenant_enabled_attribute = <%= node[:keystone][:ldap][:tenant_enabled_attribute] %>
-tenant_attribute_ignore = <%= node[:keystone][:ldap][:tenant_attribute_ignore] %>
-tenant_allow_create = <%= node[:keystone][:ldap][:tenant_allow_create] %>
-tenant_allow_update = <%= node[:keystone][:ldap][:tenant_allow_update] %>
-tenant_allow_delete = <%= node[:keystone][:ldap][:tenant_allow_delete] %>
-tenant_enabled_emulation = <%= node[:keystone][:ldap][:tenant_enabled_emulation] %>
-tenant_enabled_emulation_dn = <%= node[:keystone][:ldap][:tenant_enabled_emulation_dn] %>
-
-role_tree_dn = <%= node[:keystone][:ldap][:role_tree_dn] %>
-role_filter = <%= node[:keystone][:ldap][:role_filter] %>
-role_objectclass = <%= node[:keystone][:ldap][:role_objectclass] %>
-role_id_attribute = <%= node[:keystone][:ldap][:role_id_attribute] %>
-role_name_attribute = <%= node[:keystone][:ldap][:role_name_attribute] %>
-role_member_attribute = <%= node[:keystone][:ldap][:role_member_attribute] %>
-role_attribute_ignore = <%= node[:keystone][:ldap][:role_attribute_ignore] %>
-role_allow_create = <%= node[:keystone][:ldap][:role_allow_create] %>
-role_allow_update = <%= node[:keystone][:ldap][:role_allow_update] %>
-role_allow_delete = <%= node[:keystone][:ldap][:role_allow_delete] %>
-
-group_tree_dn = <%= node[:keystone][:ldap][:group_tree_dn] %>
-group_filter = <%= node[:keystone][:ldap][:group_filter] %>
-group_objectclass = <%= node[:keystone][:ldap][:group_objectclass] %>
-group_id_attribute = <%= node[:keystone][:ldap][:group_id_attribute] %>
-group_name_attribute = <%= node[:keystone][:ldap][:group_name_attribute] %>
-group_member_attribute = <%= node[:keystone][:ldap][:group_member_attribute] %>
-group_desc_attribute = <%= node[:keystone][:ldap][:group_desc_attribute] %>
-group_attribute_ignore = <%= node[:keystone][:ldap][:group_attribute_ignore] %>
-group_allow_create = <%= node[:keystone][:ldap][:group_allow_create] %>
-group_allow_update = <%= node[:keystone][:ldap][:group_allow_update] %>
-group_allow_delete = <%= node[:keystone][:ldap][:group_allow_delete] %>
-
-# ldap TLS options
-# if both tls_cacertfile and tls_cacertdir are set then
-# tls_cacertfile will be used and tls_cacertdir is ignored
-# valid options for tls_req_cert are demand, never, and allow
-# use_tls = False
-# tls_cacertfile =
-# tls_cacertdir =
-# tls_req_cert = demand
-
-# Additional attribute mappings can be used to map ldap attributes to internal
-# keystone attributes. This allows keystone to fulfill ldap objectclass
-# requirements. An example to map the description and gecos attributes to a
-# user's name would be:
-# user_additional_attribute_mapping = description:name, gecos:name
 #
-# domain_additional_attribute_mapping =
-# group_additional_attribute_mapping =
-# role_additional_attribute_mapping =
-# project_additional_attribute_mapping =
-# user_additional_attribute_mapping =
+# Options defined in keystone
+#
 
-[auth]
-methods = external,password,token,oauth1
-password = keystone.auth.plugins.password.Password
-token = keystone.auth.plugins.token.Token
-oauth1 = keystone.auth.plugins.oauth1.OAuth
+# delegation and impersonation features can be optionally
+# disabled. (boolean value)
+#enabled=true
 
-[paste_deploy]
-# Name of the paste configuration file that defines the available pipelines
-config_file = keystone-paste.ini
+# Keystone Trust backend driver. (string value)
+driver = keystone.token.backends.sql.Token


### PR DESCRIPTION
- Added a lot of `oslo.messaging` attributes which are unused around
  `amqp`, `rabbitmq`, `kombu`. `rpc_backend` now defaults to rabbitmq instead
  of kombu (but we were never changing this value)
- [auth].methods changed default from `external,password,token,oauth1`
  to `external,password,token`. This was set explicitly in our config,
  but I think it was only because that's how it used to be in Havana as
  we weren't using (or configuring) oauth1.
- A lot of the config options which we were hardcoding are now
  defaults (and commented in the sample config). These were left
  commented like upstream:
  - [auth].password/token/oauth1
  - [catalog].driver
  - [ec2].driver
  - [paste_deploy].config_file
  - [policy].driver
