### PR TITLE
Adding service exeption handling to keystone "wakeup" action.

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -367,7 +367,13 @@ def _find_id(http, headers, svc_name, spath, dir, key = 'name', ret = 'id')
   # Construct the path
   my_service_id = nil
   error = false
-  resp, data = http.request_get(spath, headers)
+  begin
+    resp, data = http.request_get(spath, headers)
+  rescue
+    error = true
+    Chef::Log.error("_find_id call failed, during wakeup action")
+    return [ my_service_id, error ]
+  end
   if resp.is_a?(Net::HTTPOK)
     data = JSON.parse(data)
     data = data[dir]


### PR DESCRIPTION
These changes allow:
- Check if keystone-service is up before wakeup call.
- Ensure that wakup call retries not just in case of error status response but also in case of exeption received.
