### PR TITLE
Remove version from keystone identity_uri

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -16,7 +16,7 @@ module KeystoneHelper
     end
 
     {
-      "admin_auth_url" => node[:keystone][:api][:versioned_admin_URL] || versioned_service_URL(node, node[:fqdn], node["keystone"]["api"]["admin_port"]),
+      "admin_auth_url" => node[:keystone][:api][:admin_auth_URL] || service_URL(node, node[:fqdn], node["keystone"]["api"]["admin_port"]),
       "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || versioned_service_URL(node, public_host, node["keystone"]["api"]["service_port"]),
       "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || versioned_service_URL(node, node[:fqdn], node["keystone"]["api"]["service_port"]),
       "use_ssl" => use_ssl,

--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -48,7 +48,7 @@ if node[:keystone][:frontend] == 'native'
   pacemaker_primitive service_name do
     agent node[:keystone][:ha][:agent]
     # params ({
-    #   "os_auth_url"    => node[:keystone][:api][:versioned_admin_URL],
+    #   "os_auth_url"    => node[:keystone][:api][:admin_auth_URL],
     #   "os_tenant_name" => monitor_creds[:tenant],
     #   "os_username"    => monitor_creds[:username],
     #   "os_password"    => monitor_creds[:password],


### PR DESCRIPTION
Otherwise the services can not autoselect the right keystone
version for authenticating tokens.
