### PR TITLE
Fix trust backend setting

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1322,4 +1322,4 @@ provider = keystone.token.providers.uuid.Provider
 #enabled=true
 
 # Keystone Trust backend driver. (string value)
-driver = keystone.token.backends.sql.Token
+driver = keystone.trust.backends.sql.Trust


### PR DESCRIPTION
Don't set the token driver as trust backend, it does
not work at all.
