### PR TITLE
Install openstackclient on the keystone node

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -660,6 +660,11 @@ node[:keystone][:monitor][:svcs] = [] if node[:keystone][:monitor][:svcs].nil?
 node[:keystone][:monitor][:svcs] << ["keystone"] if node[:keystone][:monitor][:svcs].empty?
 node.save
 
+# Install openstackclient so that .openrc (created below) can be used
+package "python-openstackclient" do
+  action :install
+end
+
 template "/root/.openrc" do
   source "openrc.erb"
   owner "root"


### PR DESCRIPTION
Its just useful to have it installed (its the non-deprecated
replacement of keystoneclient, which is already installed)
