### PR TITLE
Use a secure password for token

### DIFF
--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -64,7 +64,7 @@ class KeystoneService < PacemakerServiceObject
     end
 
 
-    base["attributes"][@bc_name][:service][:token] = '%012d' % rand(1e12)
+    base["attributes"][@bc_name][:service][:token] = random_password
     base["attributes"][@bc_name][:db][:password] = random_password
 
     base


### PR DESCRIPTION
The admin token is the most precious resource
in a cloud install. Better use a secure password
for it.
