### PR TITLE
Correctly set public_bind_host and admin_bind_host

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -80,10 +80,6 @@ else
   bind_service_port = node[:keystone][:api][:service_port]
 end
 
-# Ideally this would be called bind_host, not admin_host; the latter
-# is ambiguous.
-bind_host = bind_admin_host
-
 # Ideally this would be called admin_host, but that's already being
 # misleadingly used to store a value which actually represents the
 # service bind address.
@@ -287,7 +283,8 @@ template "/etc/keystone/keystone.conf" do
       :debug => node[:keystone][:debug],
       :verbose => node[:keystone][:verbose],
       :admin_token => node[:keystone][:service][:token],
-      :bind_host => bind_host,
+      :bind_admin_host => bind_admin_host,
+      :bind_service_host => bind_service_host,
       :bind_admin_port => bind_admin_port,
       :bind_service_port => bind_service_port,
       :public_endpoint => node[:keystone][:api][:public_URL],

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -14,12 +14,12 @@ admin_token = <%= @admin_token %>
 # The IP Address of the network interface to for the public
 # service to listen on. (string value)
 # Deprecated group/name - [DEFAULT]/bind_host
-public_bind_host = <%= @bind_host %>
+public_bind_host = <%= @bind_service_host %>
 
 # The IP Address of the network interface to for the admin
 # service to listen on. (string value)
 # Deprecated group/name - [DEFAULT]/bind_host
-admin_bind_host = <%= @bind_host %>
+admin_bind_host = <%= @bind_admin_host %>
 
 # The port which the OpenStack Compute service listens on.
 # (integer value)


### PR DESCRIPTION
Now that the bind_host setting has been split into public_bind_host and
admin_bind_host, we can use the correct attributes since we already had
this split in our attributes.

Note that, by default, it doesn't change anything as 0.0.0.0 is the
default values for both attributes.
