### PR TITLE
Fix keystone config to use SQL driver for EC2Credential

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -708,7 +708,7 @@ idle_timeout = <%= @sql_idle_timeout %>
 #
 
 # Keystone EC2Credential backend driver. (string value)
-#driver=keystone.contrib.ec2.backends.kvs.Ec2
+driver=keystone.contrib.ec2.backends.sql.Ec2
 
 
 [endpoint_filter]


### PR DESCRIPTION
This was lost in the update to Icehouse config.
