### PR TITLE
Configure RabbitMQ connection for Keystone

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -273,6 +273,16 @@ crowbar_pacemaker_sync_mark "create-keystone_database"
 
 sql_connection = "#{url_scheme}://#{node[:keystone][:db][:user]}:#{node[:keystone][:db][:password]}@#{sql_address}/#{node[:keystone][:db][:database]}"
 
+rabbit = get_instance('roles:rabbitmq-server')
+Chef::Log.info("Rabbit server found at #{rabbit[:rabbitmq][:address]}")
+rabbit_settings = {
+  :address => rabbit[:rabbitmq][:address],
+  :port => rabbit[:rabbitmq][:port],
+  :user => rabbit[:rabbitmq][:user],
+  :password => rabbit[:rabbitmq][:password],
+  :vhost => rabbit[:rabbitmq][:vhost]
+}
+
 template "/etc/keystone/keystone.conf" do
     source "keystone.conf.erb"
     owner node[:keystone][:user]
@@ -300,7 +310,8 @@ template "/etc/keystone/keystone.conf" do
       :ssl_certfile => node[:keystone][:ssl][:certfile],
       :ssl_keyfile => node[:keystone][:ssl][:keyfile],
       :ssl_cert_required => node[:keystone][:ssl][:cert_required],
-      :ssl_ca_certs => node[:keystone][:ssl][:ca_certs]
+      :ssl_ca_certs => node[:keystone][:ssl][:ca_certs],
+      :rabbit_settings => rabbit_settings
     )
     if node[:keystone][:frontend] == 'apache'
       notifies :restart, resources(:service => "apache2"), :immediately

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -195,11 +195,11 @@ admin_endpoint = <%= @admin_endpoint %>
 
 # The RabbitMQ broker address where a single node is used.
 # (string value)
-#rabbit_host=localhost
+rabbit_host=<%= @rabbit_settings[:address] %>
 
 # The RabbitMQ broker port where a single node is used.
 # (integer value)
-#rabbit_port=5672
+<%= "rabbit_port=#{@rabbit_settings[:port]}" unless @rabbit_settings[:port].nil? %>
 
 # RabbitMQ HA cluster host:port pairs. (list value)
 #rabbit_hosts=$rabbit_host:$rabbit_port
@@ -208,16 +208,16 @@ admin_endpoint = <%= @admin_endpoint %>
 #rabbit_use_ssl=false
 
 # The RabbitMQ userid. (string value)
-#rabbit_userid=guest
+rabbit_userid=<%= @rabbit_settings[:user] %>
 
 # The RabbitMQ password. (string value)
-#rabbit_password=guest
+rabbit_password=<%= @rabbit_settings[:password] %>
 
 # the RabbitMQ login method (string value)
 #rabbit_login_method=AMQPLAIN
 
 # The RabbitMQ virtual host. (string value)
-#rabbit_virtual_host=/
+rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 
 # How frequently to retry connecting with RabbitMQ. (integer
 # value)

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,14 +23,15 @@ barclamp:
   requires:
     - pacemaker
     - database
+    - rabbitmq
   member:
     - openstack
 
 crowbar:
   layout: 1
-  order: 75
-  run_order: 75
-  chef_order: 75
+  order: 78
+  run_order: 78
+  chef_order: 78
   proposal_schema_version: 3
 
 debs:


### PR DESCRIPTION
Keystone uses rabbitmq for user and tenant related notifications
and telemetry reporting.
