### PR TITLE
Setup admin_auth_URL also in HA mode

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -23,7 +23,7 @@ module KeystoneHelper
     end
     @keystone_settings ||= Hash.new
     @keystone_settings[cookbook_name] = {
-      "admin_auth_url" => node[:keystone][:api][:admin_auth_URL] || service_URL(node, node[:fqdn], node["keystone"]["api"]["admin_port"]),
+      "admin_auth_url" => node[:keystone][:api][:admin_URL] || service_URL(node, node[:fqdn], node["keystone"]["api"]["admin_port"]),
       "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || versioned_service_URL(node, public_host, node["keystone"]["api"]["service_port"]),
       "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || versioned_service_URL(node, node[:fqdn], node["keystone"]["api"]["service_port"]),
       "use_ssl" => use_ssl,

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -90,6 +90,7 @@ my_public_host = CrowbarHelper.get_host_for_public_url(node, node[:keystone][:ap
 node[:keystone][:api][:public_URL] = \
   KeystoneHelper.service_URL(node, my_public_host,
                              node[:keystone][:api][:service_port])
+# This is also used for admin requests of keystoneclient
 node[:keystone][:api][:admin_URL] = \
   KeystoneHelper.service_URL(node, my_admin_host,
                              node[:keystone][:api][:admin_port])


### PR DESCRIPTION
In HA mode it needs to be saved on the node so that
KeystoneSettingsHelper can find the cluster/VIP url.
