### PR TITLE
Make keystone.conf owned by root:keystone, instead of keystone:root

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -119,7 +119,8 @@ if node[:keystone][:frontend] == 'uwsgi'
   end
 
   directory "/usr/lib/cgi-bin/keystone/" do
-    owner node[:keystone][:user]
+    owner "root"
+    group "root"
     mode 0755
     action :create
     recursive true
@@ -173,7 +174,8 @@ elsif node[:keystone][:frontend] == 'apache'
 
 
   directory "/usr/lib/cgi-bin/keystone/" do
-    owner node[:keystone][:user]
+    owner "root"
+    group "root"
     mode 0755
     action :create
     recursive true
@@ -286,7 +288,8 @@ rabbit_settings = {
 
 template "/etc/keystone/keystone.conf" do
     source "keystone.conf.erb"
-    owner node[:keystone][:user]
+    owner "root"
+    group node[:keystone][:group]
     mode 0640
     variables(
       :sql_connection => sql_connection,
@@ -325,8 +328,9 @@ if %w(redhat centos).include?(node.platform)
   # Permissions for /etc/keystone are wrong in the RDO repo
   directory "/etc/keystone" do
     action :create
-    owner node[:keystone][:user]
+    owner "root"
     group node[:keystone][:group]
+    mode 0750
   end
 end
 


### PR DESCRIPTION
We don't want the keystone user to be able to write the file.

Also, don't have keystone own directories it doesn't need to own.
