### PR TITLE
Quote template values in .openrc

### DIFF
--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -1,6 +1,6 @@
 # OPENSTACK ENV VARIABLES
-export OS_USERNAME=<%= @keystone_settings['admin_user'] %>
-export OS_PASSWORD=<%= @keystone_settings['admin_password'] %>
-export OS_TENANT_NAME=<%= @keystone_settings['default_tenant'] %>
-export OS_AUTH_URL=<%= @keystone_settings['public_auth_url'] %>
+export OS_USERNAME='<%= @keystone_settings['admin_user'] %>'
+export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
+export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
+export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone


### PR DESCRIPTION
This is to keep the shell from performing variable expansion when sourcing the
.openrc file. E.g. when OS_PASSWORD contains '$'.

related to: https://bugzilla.suse.com/show_bug.cgi?id=896750

(cherry picked from commit 854de3f5dfa2a6e2ba817ab2e2819205c2648381)
