### PR TITLE
Expose region name to UI

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -502,7 +502,8 @@ end
 def endpoint_needs_update(endpoint, new_resource)
   if endpoint["publicurl"] == new_resource.endpoint_publicURL and
         endpoint["adminurl"] == new_resource.endpoint_adminURL and
-        endpoint["internalurl"] == new_resource.endpoint_internalURL
+        endpoint["internalurl"] == new_resource.endpoint_internalURL and
+        endpoint["region"] == new_resource.endpoint_region
     return false
   else
     return true

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -41,7 +41,8 @@
         "service_port": 5000,
         "api_host": "0.0.0.0",
         "admin_port": 35357,
-        "admin_host": "0.0.0.0"
+        "admin_host": "0.0.0.0",
+        "region": "RegionOne"
       },
       "admin": {
         "tenant": "admin",
@@ -143,7 +144,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 12,
+      "schema-revision": 20,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -42,7 +42,8 @@
                       "service_port": { "type" : "int", "required" : true },
                       "admin_port": { "type" : "int", "required" : true },
                       "api_host": { "type" : "str", "required" : true },
-                      "admin_host": { "type" : "str", "required" : true }
+                      "admin_host": { "type" : "str", "required" : true },
+                      "region": { "type" : "str", "required" : true }
                     }},
                     "admin": { "type": "map", "required": true, "mapping": {
                       "tenant": { "type" : "str", "required" : true },

--- a/chef/data_bags/crowbar/migrate/keystone/015_add_region.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/015_add_region.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['api']['region'] = ta['api']['region']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['api'].delete('region')
+  return a, d
+end

--- a/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/keystone/_edit_attributes.html.haml
@@ -7,6 +7,7 @@
     = instance_field :rabbitmq
     = select_field %w(frontend), :collection => :server_frontends_for_keystone
     = select_field %w(signing token_format), :collection => :token_formats_for_keystone
+    = string_field %w(api region)
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/keystone/en.yml
+++ b/crowbar_framework/config/locales/keystone/en.yml
@@ -35,6 +35,7 @@ en:
         ssl_header: 'SSL Support'
         api:
           protocol: 'Protocol'
+          region: 'Region name'
         ssl:
           generate_certs: 'Generate (self-signed) certificates (implies insecure)'
           certfile: 'SSL Certificate File'


### PR DESCRIPTION
Enable support for custom region name. This name is use to register the
keystone endpoint. It doesn't support multiple endpoints for different
regions.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
