### PR TITLE
Export custom region name in openrc file

### DIFF
--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -4,3 +4,4 @@ export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
 export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
 export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone
+export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'


### PR DESCRIPTION
OS_REGION_NAME is set to th custom region name set in Crowbar.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
