### PR TITLE
Preserve custom region on update

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/020_add_region.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/020_add_region.rb
@@ -1,9 +1,13 @@
 def upgrade ta, td, a, d
-  a['api']['region'] = ta['api']['region']
+  unless a['api'].has_key? 'region'
+    a['api']['region'] = ta['api']['region']
+  end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a['api'].delete('region')
+  unless ta['api'].has_key? 'region'
+    a['api'].delete('region')
+  end
   return a, d
 end


### PR DESCRIPTION
The migration script unconditionally overwrite the region
on update, even if it was already set. Since we backported
region support to cloud 4.x, someone could have set it
already.