### PR TITLE
Save the ID of tenants we create

### DIFF
--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -34,12 +34,15 @@ module KeystoneHelper
         "admin_port" => node["keystone"]["api"]["admin_port"],
         "admin_token" => node["keystone"]["service"]["token"],
         "admin_tenant" => node["keystone"]["admin"]["tenant"],
+        "admin_tenant_id" => node["keystone"]["admin"]["tenant_id"],
         "admin_user" => node["keystone"]["admin"]["username"],
         "admin_password" => node["keystone"]["admin"]["password"],
         "default_tenant" => node["keystone"]["default"]["tenant"],
+        "default_tenant_id" => node["keystone"]["default"]["tenant_id"],
         "default_user" => node["keystone"]["default"]["username"],
         "default_password" => node["keystone"]["default"]["password"],
-        "service_tenant" => node["keystone"]["service"]["tenant"]
+        "service_tenant" => node["keystone"]["service"]["tenant"],
+        "service_tenant_id" => node["keystone"]["service"]["tenant_id"]
       }
 
       @keystone_settings[cookbook_name]['service_user'] = current_node[cookbook_name][:service_user]

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -29,6 +29,9 @@ if %w(redhat centos).include?(node.platform)
   end
 end
 
+# useful with .openrc
+package "python-openstackclient"
+
 ha_enabled = node[:keystone][:ha][:enabled]
 
 if ha_enabled
@@ -624,11 +627,6 @@ node[:keystone][:monitor] = {} if node[:keystone][:monitor].nil?
 node[:keystone][:monitor][:svcs] = [] if node[:keystone][:monitor][:svcs].nil?
 node[:keystone][:monitor][:svcs] << ["keystone"] if node[:keystone][:monitor][:svcs].empty?
 node.save
-
-# Install openstackclient so that .openrc (created below) can be used
-package "python-openstackclient" do
-  action :install
-end
 
 template "/root/.openrc" do
   source "openrc.erb"

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -487,10 +487,9 @@ keystone_register "wakeup keystone" do
 end
 
 # Create tenants
-[ node[:keystone][:admin][:tenant],
-  node[:keystone][:service][:tenant],
-  node[:keystone][:default][:tenant]
-].each do |tenant|
+[:admin, :service, :default].each do |tenant_type|
+  tenant = node[:keystone][tenant_type][:tenant]
+
   keystone_register "add default #{tenant} tenant" do
     protocol node[:keystone][:api][:protocol]
     insecure keystone_insecure
@@ -499,6 +498,16 @@ end
     token node[:keystone][:service][:token]
     tenant_name tenant
     action :add_tenant
+  end
+
+  ruby_block "saving id for default #{tenant} tenant" do
+    block do
+      tenant_id = %x[openstack --os-token "#{node[:keystone][:service][:token]}" --os-url "#{node[:keystone][:api][:versioned_admin_URL]}" -f value -c id project show #{tenant}'].chomp
+      if !tenant_id.empty? && node[:keystone][tenant_type][:tenant_id] != tenant_id
+        node[:keystone][tenant_type][:tenant_id] = tenant_id
+        node.save
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Some other cookbooks need these ID and it's painful to have them run
these commands in a way that never breaks.

This is created to simplify the code that https://github.com/crowbar/barclamp-neutron/pull/197 tries to fix.