### PR TITLE
HA: Set Optional ordering for Keystone startup

### DIFF
--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -65,5 +65,12 @@ if node[:keystone][:frontend] == 'native'
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
+  crowbar_pacemaker_order_only_existing "o-cl-#{service_name}" do
+    ordering [ "postgresql", "rabbitmq", "cl-#{service_name}" ]
+    score "Optional"
+    action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+  end
+
   crowbar_pacemaker_sync_mark "create-keystone_ha_resources"
 end


### PR DESCRIPTION
Keystone depends on HAProxy, Database and RabbitMQ to be
started first.