### PR TITLE
Fix schema migration script for ldap keys that do not exist

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/021_ldap_tenants_to_projects.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/021_ldap_tenants_to_projects.rb
@@ -1,6 +1,6 @@
 def upgrade ta, td, a, d
   %w{ tree_dn filter objectclass domain_id_attribute id_attribute member_attribute name_attribute desc_attribute enabled_attribute attribute_ignore allow_create allow_update allow_delete enabled_emulation enabled_emulation_dn }.each do |attr|
-    a['ldap']["project_#{attr}"] = a['ldap']["tenant_#{attr}"]
+    a['ldap']["project_#{attr}"] = a['ldap']["tenant_#{attr}"] || ta['ldap']["project_#{attr}"]
     a['ldap'].delete "tenant_#{attr}"
   end
 
@@ -9,7 +9,7 @@ end
 
 def downgrade ta, td, a, d
   %w{ tree_dn filter objectclass domain_id_attribute id_attribute member_attribute name_attribute desc_attribute enabled_attribute attribute_ignore allow_create allow_update allow_delete enabled_emulation enabled_emulation_dn }.each do |attr|
-    a['ldap']["tenant_#{attr}"] = a['ldap']["project_#{attr}"]
+    a['ldap']["tenant_#{attr}"] = a['ldap']["project_#{attr}"] || ta['ldap']["tenant_#{attr}"]
     a['ldap'].delete "project_#{attr}"
   end
 


### PR DESCRIPTION
For old setups (based on roxy? or even earlier?), the tennant_* ldap
keys are not in the keystone proposal, so the migration script will just
put null values instead of valid values.