### PR TITLE
Allow custom policy_file path

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -28,6 +28,8 @@ default[:keystone][:debug] = false
 default[:keystone][:frontend] = 'apache'
 default[:keystone][:verbose] = false
 
+default[:keystone][:policy_file] = "policy.json"
+
 default[:keystone][:db][:database] = "keystone"
 default[:keystone][:db][:user] = "keystone"
 default[:keystone][:db][:password] = "" # Set by Recipe

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -440,6 +440,7 @@ use_syslog = <%= @use_syslog ? "True" : "False" %>
 
 # The JSON file that defines policies. (string value)
 #policy_file=policy.json
+policy_file = <%= node[:keystone][:policy_file] %>
 
 # Default rule. Enforced when a requested rule is not found.
 # (string value)

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -19,6 +19,7 @@
           "pip://MySQL-python"
       ],
       "use_syslog": false,
+      "policy_file": "policy.json",
       "database_instance": "none",
       "rabbitmq_instance": "none",
       "db": {
@@ -146,7 +147,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 22,
+      "schema-revision": 23,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -19,6 +19,7 @@
                     "use_virtualenv": { "type": "bool", "required": true },
                     "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "use_syslog": { "type": "bool", "required": true },
+                    "policy_file": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
                     "rabbitmq_instance": { "type": "str", "required": true },
                     "db": { "type": "map", "required": true, "mapping": {

--- a/chef/data_bags/crowbar/migrate/keystone/023_add_policy_file.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/023_add_policy_file.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['policy_file'] = ta['policy_file']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('policy_file')
+  return a, d
+end


### PR DESCRIPTION
To be able to customize the used policy rules, allow a different path to
a policy file. This way the customized file is not overwritten during a
package update.