### PR TITLE
Use the right region when fetching tenant IDs

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -505,7 +505,7 @@ end
 
   ruby_block "saving id for default #{tenant} tenant" do
     block do
-      tenant_id = %x[openstack --os-token "#{node[:keystone][:service][:token]}" --os-url "#{node[:keystone][:api][:versioned_admin_URL]}" -f value -c id project show #{tenant}'].chomp
+      tenant_id = %x[openstack --os-token "#{node[:keystone][:service][:token]}" --os-url "#{node[:keystone][:api][:versioned_admin_URL]}" --os-region "#{node["keystone"]["api"]["region"]}" -f value -c id project show #{tenant}'].chomp
       if !tenant_id.empty? && node[:keystone][tenant_type][:tenant_id] != tenant_id
         node[:keystone][tenant_type][:tenant_id] = tenant_id
         node.save


### PR DESCRIPTION
Sorry, missed that in https://github.com/crowbar/barclamp-keystone/pull/264