### PR TITLE
WIP: Update keystone_register to use the v3 API

### DIFF
--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -61,27 +61,15 @@ action :add_service do
   end
 end
 
+action :add_project do
+  add_project(new_resource.project_name)
+end
+
 # :add_tenant specific attributes
 # attribute :tenant_name, :kind_of => String
 action :add_tenant do
-  http, headers = _build_connection(new_resource)
-
-  # Construct the path
-  path = '/v3/projects'
-  dir = 'projects'
-
-  # Lets verify that the service does not exist yet
-  item_id, error = _find_id(http, headers, new_resource.tenant_name, path, dir)
-  unless item_id or error
-    # Service does not exist yet
-    body = _build_project_object(new_resource.tenant_name)
-    ret = _create_item(http, headers, path, body, new_resource.tenant_name)
-    new_resource.updated_by_last_action(ret)
-  else
-    raise "Failed to talk to keystone in add_tenant" if error
-    Chef::Log.info "Tenant '#{new_resource.tenant_name}' already exists. Not creating." unless error
-    new_resource.updated_by_last_action(false)
-  end
+  Chef::Log.warn "keystone_register action ':add_tenant' is deprecated please use ':add_project'"
+  add_project(new_resource.tenant_name)
 end
 
 # :add_user specific attributes
@@ -312,6 +300,27 @@ action :add_endpoint_template do
   end
 end
 
+private
+def add_project(project_name)
+  http, headers = _build_connection(new_resource)
+
+  # Construct the path
+  path = '/v3/projects'
+  dir = 'projects'
+
+  # Lets verify that the service does not exist yet
+  item_id, error = _find_id(http, headers, project_name, path, dir)
+  unless item_id or error
+    # Service does not exist yet
+    body = _build_project_object(project_name)
+    ret = _create_item(http, headers, path, body, project_name)
+    new_resource.updated_by_last_action(ret)
+  else
+    raise "Failed to talk to keystone in add_project" if error
+    Chef::Log.info "Project '#{project_name}' already exists. Not creating." unless error
+    new_resource.updated_by_last_action(false)
+  end
+end
 
 # Return true on success
 private

--- a/chef/cookbooks/keystone/providers/register.rb
+++ b/chef/cookbooks/keystone/providers/register.rb
@@ -207,7 +207,8 @@ action :add_ec2 do
   tenant_id, terror = _find_id(http, headers, tenant, '/v3/projects', 'projects')
 
   path = "/v3/users/#{user_id}/credentials/OS-EC2"
-  t_tenant_id, aerror = _find_id(http, headers, tenant_id, path, 'credentials', 'project_id', 'project_id')
+  # Note: tenant_id is correct here even when using the V3 API
+  t_tenant_id, aerror = _find_id(http, headers, tenant_id, path, 'credentials', 'tenant_id', 'tenant_id')
 
   error = (aerror or uerror or terror)
   unless tenant_id == t_tenant_id or error
@@ -480,6 +481,7 @@ end
 private
 def _build_ec2_object(tenant_id)
   ret = Hash.new
+  # Note: tenant_id is correct here even when using the V3 API
   ret.store("tenant_id", tenant_id)
   return ret
 end

--- a/chef/cookbooks/keystone/resources/register.rb
+++ b/chef/cookbooks/keystone/resources/register.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :add_service, :add_endpoint_template, :add_tenant, :add_user, :add_role, :add_access, :add_ec2, :wakeup
+actions :add_service, :add_endpoint_template, :add_project, :add_tenant, :add_user, :add_role, :add_access, :add_ec2, :wakeup
 
 attribute :protocol, :kind_of => String
 attribute :insecure, :kind_of => [TrueClass, FalseClass], :default => false
@@ -41,6 +41,9 @@ attribute :endpoint_internalURL, :kind_of => String
 attribute :endpoint_publicURL, :kind_of => String
 attribute :endpoint_global, :default => true
 attribute :endpoint_enabled, :default => true
+
+# :add_project specific attributes
+attribute :project_name, :kind_of => String
 
 # :add_tenant specific attributes
 attribute :tenant_name, :kind_of => String


### PR DESCRIPTION
This is still imcomplete and needs work. Especially the keystone_register provider needs more changes when it comes to endpoint registration and the tenant -> project renaming. 

BTW, I opted for not trying to make the keystone_register provider compatible with both API versions as that would make it even more complex. So it will always use v3 independent of what is set in the attribute.
