### PR TITLE
Set the default parameters for the hybrid backend (bsc#928718)

### DIFF
--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -808,6 +808,11 @@ driver = <%= node[:keystone][:identity][:driver] %>
 # value)
 #default_lock_timeout=5
 
+<% if node[:keystone][:assignment][:driver] == 'keystone.assignment.backends.hybrid.Assignment' %>
+[ldap_hybrid]
+default_roles = Member
+default_project = <%= node[:keystone][:default][:tenant] %>
+<% end %>
 
 [ldap]
 


### PR DESCRIPTION
The hybrid backend removed the hardcoded values for default_project and
default_roles and made them config option. Set them to values which make sense
in the crowbar setup.

(cherry picked from commit 4132d0ea9c21e50843254fff29e0796573480447)