### PR TITLE
Groud work for keystone v3 changes

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -39,7 +39,7 @@ default[:keystone][:api][:service_port] = 5000
 default[:keystone][:api][:admin_port] = 35357
 default[:keystone][:api][:admin_host] = "0.0.0.0"
 default[:keystone][:api][:api_host] = "0.0.0.0"
-default[:keystone][:api][:version] = "v2.0"
+default[:keystone][:api][:version] = "2.0"
 default[:keystone][:api][:region] = "RegionOne"
 
 default[:keystone][:identity][:driver] = "keystone.identity.backends.sql.Identity"

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -37,6 +37,10 @@ module KeystoneHelper
       @keystone_settings ||= Hash.new
       @keystone_settings[cookbook_name] = {
         "api_version" => node[:keystone][:api][:version],
+        # This is somehwat ugly but the Juno keystonemiddleware expects the
+        # version to be a "v3.0" for the v3 API instead of the "v3" or "3" that
+        # is used everywhere else.
+        "api_version_for_middleware" => "v%.1f" % node[:keystone][:api][:version],
         "admin_auth_url" => node[:keystone][:api][:admin_URL] || admin_auth_url,
         "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || public_auth_url,
         "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || internal_auth_url,

--- a/chef/cookbooks/keystone/libraries/helpers.rb
+++ b/chef/cookbooks/keystone/libraries/helpers.rb
@@ -36,7 +36,7 @@ module KeystoneHelper
 
       @keystone_settings ||= Hash.new
       @keystone_settings[cookbook_name] = {
-        "api_version" => node[:keystone][:api][:version].sub(/^v/, ""),
+        "api_version" => node[:keystone][:api][:version],
         "admin_auth_url" => node[:keystone][:api][:admin_URL] || admin_auth_url,
         "public_auth_url" => node[:keystone][:api][:versioned_public_URL] || public_auth_url,
         "internal_auth_url" => node[:keystone][:api][:versioned_internal_URL] || internal_auth_url,

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -498,6 +498,11 @@ keystone_register "wakeup keystone" do
 end
 
 # Create tenants
+openstack_command = "openstack --os-token \"#{node[:keystone][:service][:token]}\" --os-url \"#{node[:keystone][:api][:versioned_admin_URL]}\" --os-region \"#{node[:keystone][:api][:region]}\""
+if node[:keystone][:api][:version] != '2.0'
+  openstack_command <<  " --os-identity-api-version #{node[:keystone][:api][:version]} --os-project-domain-id default --os-user-domain-id default"
+end
+
 [:admin, :service, :default].each do |tenant_type|
   tenant = node[:keystone][tenant_type][:tenant]
 
@@ -513,7 +518,7 @@ end
 
   ruby_block "saving id for default #{tenant} tenant" do
     block do
-      tenant_id = %x[openstack --os-token "#{node[:keystone][:service][:token]}" --os-url "#{node[:keystone][:api][:versioned_admin_URL]}" --os-region "#{node[:keystone][:api][:region]}" project show -f value -c id #{tenant}].chomp
+      tenant_id = %x[#{openstack_command} project show -f value -c id #{tenant}].chomp
       if !tenant_id.empty? && node[:keystone][tenant_type][:tenant_id] != tenant_id
         node[:keystone][tenant_type][:tenant_id] = tenant_id
         node.save

--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -2,7 +2,11 @@
 export OS_USERNAME='<%= @keystone_settings['admin_user'] %>'
 export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
 export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
+<% if @keystone_settings['api_version'] != '2.0' %>
 export OS_IDENTITY_API_VERSION='<%= @keystone_settings['api_version'] %>'
+export OS_USER_DOMAIN_NAME='Default'
+export OS_PROJECT_DOMAIN_NAME='Default'
+<% end %>
 export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone
 export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'

--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -2,6 +2,7 @@
 export OS_USERNAME='<%= @keystone_settings['admin_user'] %>'
 export OS_PASSWORD='<%= @keystone_settings['admin_password'] %>'
 export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
+export OS_IDENTITY_API_VERSION='<%= @keystone_settings['api_version'] %>'
 export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone
 export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'

--- a/chef/cookbooks/keystone/templates/default/openrc.erb
+++ b/chef/cookbooks/keystone/templates/default/openrc.erb
@@ -6,6 +6,7 @@ export OS_TENANT_NAME='<%= @keystone_settings['default_tenant'] %>'
 export OS_IDENTITY_API_VERSION='<%= @keystone_settings['api_version'] %>'
 export OS_USER_DOMAIN_NAME='Default'
 export OS_PROJECT_DOMAIN_NAME='Default'
+export OS_AUTH_VERSION='<%= @keystone_settings['api_version'] %>'
 <% end %>
 export OS_AUTH_URL='<%= @keystone_settings['public_auth_url'] %>'
 export OS_AUTH_STRATEGY=keystone

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -31,7 +31,7 @@
         "api_host": "0.0.0.0",
         "admin_port": 35357,
         "admin_host": "0.0.0.0",
-        "version": "v2.0",
+        "version": "2.0",
         "region": "RegionOne"
       },
       "admin": {

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -31,6 +31,7 @@
         "api_host": "0.0.0.0",
         "admin_port": 35357,
         "admin_host": "0.0.0.0",
+        "version": "v2.0",
         "region": "RegionOne"
       },
       "admin": {
@@ -135,7 +136,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 30,
+      "schema-revision": 31,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -36,6 +36,7 @@
                       "admin_port": { "type" : "int", "required" : true },
                       "api_host": { "type" : "str", "required" : true },
                       "admin_host": { "type" : "str", "required" : true },
+                      "version": { "type" : "str", "required" : true },
                       "region": { "type" : "str", "required" : true }
                     }},
                     "admin": { "type": "map", "required": true, "mapping": {

--- a/chef/data_bags/crowbar/migrate/keystone/031_add_version.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/031_add_version.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['api']['version'] = ta['api']['version']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['api'].delete('version')
+  return a, d
+end

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -74,6 +74,11 @@ class KeystoneService < PacemakerServiceObject
   def validate_proposal_after_save proposal
     validate_one_for_role proposal, "keystone-server"
 
+    api_versions = ["v2.0", "v3"]
+    unless api_versions.include? proposal["attributes"][@bc_name]["api"]["version"]
+      validation_error("API version #{proposal[:attributes][@bc_name][:api][:version]} not recognized.")
+    end
+
     super
   end
 

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -74,7 +74,7 @@ class KeystoneService < PacemakerServiceObject
   def validate_proposal_after_save proposal
     validate_one_for_role proposal, "keystone-server"
 
-    api_versions = ["v2.0", "v3"]
+    api_versions = ["2.0", "3"]
     unless api_versions.include? proposal["attributes"][@bc_name]["api"]["version"]
       validation_error("API version #{proposal[:attributes][@bc_name][:api][:version]} not recognized.")
     end


### PR DESCRIPTION
This pull request should contain the minimal changes required for keystone v3 support. It's a subset of https://github.com/crowbar/barclamp-keystone/pull/277 and should help to speed up review and merging of the changes to the other barclamps independent of  the bigger changes in: https://github.com/crowbar/barclamp-keystone/pull/277

It intention is to have this merged first (v2 functionality should keep working without changes, v3 will only work after the other barclamp have been updated as well), then merge the PRs on the other barclamps and finally merge the rest of the keystone changes in #277.