### PR TITLE
Allow to enable domain specific drivers

### DIFF
--- a/chef/cookbooks/keystone/attributes/default.rb
+++ b/chef/cookbooks/keystone/attributes/default.rb
@@ -27,6 +27,8 @@ default[:keystone][:group] = "keystone"
 default[:keystone][:debug] = false
 default[:keystone][:frontend] = 'apache'
 default[:keystone][:verbose] = false
+default[:keystone][:domain_specific_drivers] = false
+default[:keystone][:domain_config_dir] = "/etc/keystone/domains"
 
 default[:keystone][:policy_file] = "policy.json"
 

--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -277,6 +277,14 @@ if %w(redhat centos).include?(node.platform)
   end
 end
 
+directory node[:keystone][:domain_config_dir] do
+  action :create
+  owner "root"
+  group node[:keystone][:group]
+  mode 0750
+  only_if { node[:keystone][:domain_specific_drivers] }
+end
+
 crowbar_pacemaker_sync_mark "wait-keystone_db_sync"
 
 execute "keystone-manage db_sync" do

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -780,11 +780,15 @@ driver=keystone.contrib.ec2.backends.sql.Ec2
 # configuration file. This feature is disabled by default; set
 # to true to enable. (boolean value)
 #domain_specific_drivers_enabled=false
+domain_specific_drivers_enabled = <%= node[:keystone][:domain_specific_drivers] ? "True" : "False" %>
 
 # Path for Keystone to locate the domain specific identity
 # configuration files if domain_specific_drivers_enabled is
 # set to true. (string value)
 #domain_config_dir=/etc/keystone/domains
+<% if node[:keystone][:domain_specific_drivers] %>
+domain_config_dir = <%= node[:keystone][:domain_config_dir] %>
+<% end %>
 
 # Keystone Identity backend driver. (string value)
 driver = <%= node[:keystone][:identity][:driver] %>

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -10,6 +10,8 @@
       "policy_file": "policy.json",
       "database_instance": "none",
       "rabbitmq_instance": "none",
+      "domain_specific_drivers": false,
+      "domain_config_dir": "/etc/keystone/domains",
       "db": {
         "database": "keystone",
         "user": "keystone"

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -14,6 +14,8 @@
                     "policy_file": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
                     "rabbitmq_instance": { "type": "str", "required": true },
+                    "domain_specific_drivers": { "type": "bool", "required": true },
+                    "domain_config_dir": { "type": "str", "required": true },
                     "db": { "type": "map", "required": true, "mapping": {
                       "database": { "type" : "str", "required" : true },
                       "user": { "type" : "str", "required" : true },

--- a/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/032_add_domain_specific_drivers.rb
@@ -1,0 +1,11 @@
+def upgrade ta, td, a, d
+  a['domain_specific_drivers'] = ta['domain_specific_drivers']
+  a['domain_config_dir'] = ta['domain_config_dir']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('domain_specific_drivers')
+  a.delete('domain_config_dir')
+  return a, d
+end

--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -79,6 +79,12 @@ class KeystoneService < PacemakerServiceObject
       validation_error("API version #{proposal[:attributes][@bc_name][:api][:version]} not recognized.")
     end
 
+    # Using domains requires API Version 3 or newer
+    if proposal["attributes"][@bc_name]["domain_specific_drivers"] &&
+        proposal["attributes"][@bc_name]["api"]["version"].to_f < 3.0
+      validation_error("API version 3 or newer is required when enabling domain specific drivers.")
+    end
+
     super
   end
 


### PR DESCRIPTION
This just enables the keystone configuration option for domain specific
drivers. The per domain config files have to be placed manually into the
domain_config_directory (/etc/keystone/domains/ by default) on the keystone
nodes.