### PR TITLE
Fix up migration after tex backport

### DIFF
--- a/chef/data_bags/crowbar/migrate/keystone/031_add_version.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/031_add_version.rb
@@ -1,9 +1,13 @@
 def upgrade ta, td, a, d
-  a['api']['version'] = ta['api']['version']
+  unless a['api'].has_key? 'version'
+    a['api']['version'] = ta['api']['version']
+  end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a['api'].delete('version')
+  unless ta['api'].has_key? 'version'
+    a['api'].delete('version')
+  end
   return a, d
 end


### PR DESCRIPTION
Do not overwrite the api version if it was already set.