### PR TITLE
Make token expiration configurable (bsc#941537)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -251,6 +251,7 @@ template "/etc/keystone/keystone.conf" do
       :signing_certfile => node[:keystone][:signing][:certfile],
       :signing_keyfile => node[:keystone][:signing][:keyfile],
       :signing_ca_certs => node[:keystone][:signing][:ca_certs],
+      :token_expiration => node[:keystone][:token_expiration],
       :protocol => node[:keystone][:api][:protocol],
       :frontend => node[:keystone][:frontend],
       :ssl_enable => (node[:keystone][:frontend] == 'native' && node[:keystone][:api][:protocol] == "https"),

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1516,7 +1516,7 @@ cert_required = <%= @ssl_cert_required %>
 
 # Amount of time a token should remain valid (in seconds).
 # (integer value)
-#expiration=3600
+expiration=<%= @token_expiration %>
 
 # Controls the token construction, validation, and revocation
 # operations. Core providers are

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -12,6 +12,7 @@
       "rabbitmq_instance": "none",
       "domain_specific_drivers": false,
       "domain_config_dir": "/etc/keystone/domains",
+      "token_expiration": 14400,
       "db": {
         "database": "keystone",
         "user": "keystone"

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -16,6 +16,7 @@
                     "rabbitmq_instance": { "type": "str", "required": true },
                     "domain_specific_drivers": { "type": "bool", "required": true },
                     "domain_config_dir": { "type": "str", "required": true },
+                    "token_expiration": { "type" : "int", "required" : true },
                     "db": { "type": "map", "required": true, "mapping": {
                       "database": { "type" : "str", "required" : true },
                       "user": { "type" : "str", "required" : true },


### PR DESCRIPTION
Horizon session timeout is dependant also on the keystone
token timeout, which is "only" 1h by default. Raise this to
four hours and make it configurable via the hidden crowbar proposal.