### PR TITLE
Make token expiration configurable (bsc#941537)

### DIFF
--- a/chef/cookbooks/keystone/recipes/server.rb
+++ b/chef/cookbooks/keystone/recipes/server.rb
@@ -299,6 +299,7 @@ template "/etc/keystone/keystone.conf" do
       :signing_certfile => node[:keystone][:signing][:certfile],
       :signing_keyfile => node[:keystone][:signing][:keyfile],
       :signing_ca_certs => node[:keystone][:signing][:ca_certs],
+      :token_expiration => node[:keystone][:token_expiration],
       :protocol => node[:keystone][:api][:protocol],
       :frontend => node[:keystone][:frontend],
       :ssl_enable => (node[:keystone][:frontend] == 'native' && node[:keystone][:api][:protocol] == "https"),

--- a/chef/cookbooks/keystone/templates/default/keystone.conf.erb
+++ b/chef/cookbooks/keystone/templates/default/keystone.conf.erb
@@ -1512,7 +1512,7 @@ cert_required = <%= @ssl_cert_required %>
 
 # Amount of time a token should remain valid (in seconds).
 # (integer value)
-#expiration=3600
+expiration=<%= @token_expiration %>
 
 # Controls the token construction, validation, and revocation
 # operations. Core providers are

--- a/chef/data_bags/crowbar/bc-template-keystone.json
+++ b/chef/data_bags/crowbar/bc-template-keystone.json
@@ -22,6 +22,7 @@
       "policy_file": "policy.json",
       "database_instance": "none",
       "rabbitmq_instance": "none",
+      "token_expiration": 14400,
       "db": {
         "database": "keystone",
         "user": "keystone"
@@ -148,7 +149,7 @@
     "keystone": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 24,
+      "schema-revision": 25,
       "element_states": {
         "keystone-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-keystone.schema
+++ b/chef/data_bags/crowbar/bc-template-keystone.schema
@@ -22,6 +22,7 @@
                     "policy_file": { "type": "str", "required": true },
                     "database_instance": { "type": "str", "required": true },
                     "rabbitmq_instance": { "type": "str", "required": true },
+                    "token_expiration": { "type" : "int", "required" : true },
                     "db": { "type": "map", "required": true, "mapping": {
                       "database": { "type" : "str", "required" : true },
                       "user": { "type" : "str", "required" : true },

--- a/chef/data_bags/crowbar/migrate/keystone/025_add_token_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/keystone/025_add_token_timeout.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  unless a.has_key? "token_expiration"
+    a["token_expiration"] = ta["token_expiration"]
+  end
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  unless ta.has_key? "token_expiration"
+    a.delete("token_expiration")
+  end
+  return a, d
+end


### PR DESCRIPTION
Horizon session timeout is dependant also on the keystone
token timeout, which is "only" 1h by default. Raise this to
four hours and make it configurable via the hidden crowbar proposal.