### PR TITLE
Add warning for horizon timeout

### DIFF
--- a/crowbar_framework/app/models/keystone_service.rb
+++ b/crowbar_framework/app/models/keystone_service.rb
@@ -94,6 +94,18 @@ class KeystoneService < PacemakerServiceObject
       validation_error("Keystone API version 3 needs to be enabled in order to use domain specific drivers.")
     end
 
+    keystone_timeout = proposal["attributes"]["keystone"]["token_expiration"]
+    horizon_proposal = ProposalObject.find_proposal("nova_dashboard", "default")
+    unless horizon_proposal.nil?
+      horizon_timeout = horizon_proposal["attributes"]["nova_dashboard"]["session_timeout"]
+
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error("Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the "\
+          "Keystone token expiration timeout (#{keystone_timeout / 60} minutes) is not supported.")
+      end
+    end
+
     super
   end
 


### PR DESCRIPTION
Horizon timeout is impacted by keystone token timeout since when the
token gets outdated, then the user is automatically unable to use
horizon. This patch includes a check for the timeout of horizon and
keystone barclamps.
