### PR TITLE
interleave Pacemaker clones to minimise disruption (bsc#965886)

### DIFF
--- a/chef/cookbooks/keystone/recipes/ha.rb
+++ b/chef/cookbooks/keystone/recipes/ha.rb
@@ -62,6 +62,9 @@ if node[:keystone][:frontend] == 'native'
   pacemaker_clone "cl-#{service_name}" do
     rsc service_name
     action [:create, :start]
+    meta ({
+      "interleave" => "true",
+    })
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 


### PR DESCRIPTION
By default, Pacemaker clones aren't interleaved.  This means that if
Pacemaker wants to restart a dead clone instance, and there is an order
constraint on that clone, it will do the same restart on all other
nodes, even if all the others are healthy.

More details on interleaving are here:

  https://www.hastexo.com/resources/hints-and-kinks/interleaving-pacemaker-clones/

This behaviour is far more disruptive than we want.  For example, in

  https://bugzilla.suse.com/show_bug.cgi?id=965886

we saw that when a network node dies and Pacemaker wants to stop the
instance of cl-g-neutron-agents on that node, it also stops and restarts
the same clone instances on the healthy nodes.  This means there is a
small window in which there are no neutron agents running anywhere.  If
neutron-ha-tool attempts a router migration during this window, it will
fail, at which point things start to go badly wrong.

In general, the cloned (i.e. active/active) services on our controller
and compute nodes should all behave like independent vertical stacks,
so that a failure on one node should not cause ripple effects on other
nodes.  So we interleave all our clones.

(There is a corresponding commit to crowbar-ha for the Apache clone.)

(cherry picked from commit bdde4b4dc2534e91bf1f2869a66491463134f8c1)
